### PR TITLE
Set git email and name globally

### DIFF
--- a/src/scripts/setup-git-config.sh
+++ b/src/scripts/setup-git-config.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-git config user.email "$GIT_EMAIL"
-git config user.name "$GIT_USERNAME"
+git config --global user.email "$GIT_EMAIL"
+git config --global user.name "$GIT_USERNAME"


### PR DESCRIPTION
This was causing https://github.com/RevenueCat/cordova-plugin-purchases/pull/195 to fail deploying docs