### PR TITLE
Update gradle cache tasks to use catalogs

### DIFF
--- a/src/commands/restore-gradle-cache.yml
+++ b/src/commands/restore-gradle-cache.yml
@@ -9,7 +9,7 @@ steps:
   - generate-gradle-checksums
   - restore_cache:
       keys:
-        - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "gradle-checksums.txt" }}-{{ checksum "date.txt" }}
-        - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "gradle-checksums.txt" }}
-        - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-
+        - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle-checksums.txt" }}-{{ checksum "date.txt" }}
+        - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle-checksums.txt" }}
+        - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "gradle/libs.versions.toml" }}-
         - <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-

--- a/src/commands/save-gradle-cache.yml
+++ b/src/commands/save-gradle-cache.yml
@@ -9,4 +9,4 @@ steps:
   - save_cache:
       paths:
         - ~/.gradle
-      key: <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "build.gradle" }}-{{ checksum "gradle-checksums.txt" }}-{{ checksum "date.txt" }}
+      key: <<parameters.cache-prefix>>-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ checksum "gradle/libs.versions.toml" }}-{{ checksum "gradle-checksums.txt" }}-{{ checksum "date.txt" }}

--- a/src/scripts/compute-gradle-checksums.sh
+++ b/src/scripts/compute-gradle-checksums.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This finds all *.gradle files (apart from the root build.gradle) and generates checksums for caching
-find . -mindepth 2 -name "*.gradle" -type f | sort | xargs shasum > gradle-checksums.txt
+find . -mindepth 2 -name "*.gradle.kts" -type f | sort | xargs shasum > gradle-checksums.txt
 cat gradle-checksums.txt
 # Output the current date in order to prevent a very stale cache
 date +"%Y/%m/%d" > date.txt


### PR DESCRIPTION
After updating PHC https://github.com/RevenueCat/purchases-hybrid-common/pull/603 to use kotlin dsl and version catalogs, the cache in circle ci stopped working. This updates to use the catalog file to compute the checksum for the dependencies, instead of the build.gradle.

Note this task was only being used in PHC, so it should be safe to update this. We could move it to PHC as well but wanted to minify the changes.