### PR TITLE
Add Ruby version parameter to danger job

### DIFF
--- a/src/jobs/danger.yml
+++ b/src/jobs/danger.yml
@@ -1,7 +1,12 @@
 description: >
   Runs Danger checks
+parameters:
+  ruby_version:
+    type: string
+    default: "3.1.2"
+    description: "Ruby version to use for the Docker image"
 docker:
-  - image: cimg/ruby:3.1.2
+  - image: cimg/ruby:<< parameters.ruby_version >>
 shell: /bin/bash --login -o pipefail
 steps:
   - checkout


### PR DESCRIPTION
In case we want to use a version that's not 3.1.2