### PR TITLE
Remove `github_rate_limit` from automatic bump command

### DIFF
--- a/src/jobs/automatic-bump.yml
+++ b/src/jobs/automatic-bump.yml
@@ -16,4 +16,4 @@ steps:
       cache-version: v1
   - run:
       name: Create automatic PR
-      command: bundle exec fastlane automatic_bump github_rate_limit:10
+      command: bundle exec fastlane automatic_bump


### PR DESCRIPTION
We are correctly using a GitHub token now so this is not needed