### PR TITLE
Fall back to auto-merge + branch update when direct merge fails

### DIFF
--- a/src/jobs/merge-release-pr.yml
+++ b/src/jobs/merge-release-pr.yml
@@ -1,5 +1,9 @@
 description: >
-  Merges the release PR directly via the REST API
+  Merges the release PR directly via the REST API. If the merge fails
+  (e.g. branch not up-to-date) and merge queue is not in use, enables
+  auto-merge and updates the PR branch instead. In that case the job
+  exits successfully but the actual merge happens asynchronously once
+  CI passes on the updated branch.
 parameters:
   ruby_version:
     type: string
@@ -34,7 +38,7 @@ steps:
   - install-gem-unix-dependencies:
       cache-version: v1
   - run:
-      name: Merge release PR
+      name: Merge release PR (with auto-merge fallback)
       environment:
         REPO_NAME: << parameters.repo_name >>
         VERSION: << parameters.version >>

--- a/src/scripts/merge-release-pr.sh
+++ b/src/scripts/merge-release-pr.sh
@@ -7,6 +7,8 @@ else
     version="$(tr -d '\n' < "${VERSION_FILE}")"
 fi
 
+release_branch="release/${version}"
+
 using_merge_queue=false
 merge_queue_arg=""
 if [ "${USE_MERGE_QUEUE}" = "1" ] || [ "${USE_MERGE_QUEUE}" = "true" ]; then
@@ -17,7 +19,7 @@ fi
 merge_exit_code=0
 bundle exec fastlane run merge_pr \
     repo_name:"${REPO_NAME}" \
-    branch:"release/${version}" \
+    branch:"${release_branch}" \
     merge_method:"${MERGE_METHOD}" \
     ${merge_queue_arg} || merge_exit_code=$?
 
@@ -34,11 +36,11 @@ echo "Direct merge failed. Enabling auto-merge and updating branch..."
 
 bundle exec fastlane run enable_auto_merge_for_pr \
     repo_name:"${REPO_NAME}" \
-    branch:"release/${version}" \
+    branch:"${release_branch}" \
     merge_method:"${MERGE_METHOD}"
 
 bundle exec fastlane run update_pr_branch \
     repo_name:"${REPO_NAME}" \
-    branch:"release/${version}"
+    branch:"${release_branch}"
 
 echo "Auto-merge enabled and branch updated. The PR will merge automatically once CI passes."

--- a/src/scripts/merge-release-pr.sh
+++ b/src/scripts/merge-release-pr.sh
@@ -7,13 +7,38 @@ else
     version="$(tr -d '\n' < "${VERSION_FILE}")"
 fi
 
+using_merge_queue=false
 merge_queue_arg=""
 if [ "${USE_MERGE_QUEUE}" = "1" ] || [ "${USE_MERGE_QUEUE}" = "true" ]; then
+    using_merge_queue=true
     merge_queue_arg="use_merge_queue:true"
 fi
 
+merge_exit_code=0
 bundle exec fastlane run merge_pr \
     repo_name:"${REPO_NAME}" \
     branch:"release/${version}" \
     merge_method:"${MERGE_METHOD}" \
-    ${merge_queue_arg}
+    ${merge_queue_arg} || merge_exit_code=$?
+
+if [ "${merge_exit_code}" -eq 0 ]; then
+    exit 0
+fi
+
+if [ "${using_merge_queue}" = true ]; then
+    echo "Merge queue enqueue failed."
+    exit "${merge_exit_code}"
+fi
+
+echo "Direct merge failed. Enabling auto-merge and updating branch..."
+
+bundle exec fastlane run enable_auto_merge_for_pr \
+    repo_name:"${REPO_NAME}" \
+    branch:"release/${version}" \
+    merge_method:"${MERGE_METHOD}"
+
+bundle exec fastlane run update_pr_branch \
+    repo_name:"${REPO_NAME}" \
+    branch:"release/${version}"
+
+echo "Auto-merge enabled and branch updated. The PR will merge automatically once CI passes."


### PR DESCRIPTION
## Summary

- When the direct merge of a release PR fails (e.g. because the branch is not up-to-date with main), and merge queue is not in use, the `merge-release-pr` job now falls back to:
  1. Enabling auto-merge on the PR (with the same merge method)
  2. Updating the PR branch by merging the base branch into it via the GitHub API

This handles repos like `purchases-flutter` that have the "Require branches to be up to date before merging" branch protection rule. See [this pipeline](https://app.circleci.com/pipelines/github/RevenueCat/purchases-flutter/5615) for an example of the failures this fixes.

**Note:** When the fallback fires, the job exits successfully but the merge hasn't actually happened yet — it completes asynchronously once CI passes on the updated branch.

**Depends on:** [fastlane-plugin-revenuecat_internal#125](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/125) (new `update_pr_branch` action).

## Test plan

- [ ] Verify the orb packs and lints successfully
- [ ] Test on a repo with "require up-to-date" branch protection by triggering a release where main has diverged
- [ ] Verify merge queue path still fails normally on enqueue errors