### PR TITLE
Add CODEOWNERS with @RevenueCat/sdk as default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS for sdks-circleci-orb
+
+# Default owners
+* @RevenueCat/sdk


### PR DESCRIPTION
## Summary
- Add a CODEOWNERS file with `@RevenueCat/sdk` as the default code owner
- The "Require review from Code Owners" branch protection setting is being enabled organization-wide. This repo didn't have a CODEOWNERS file, so one is being added with the `@RevenueCat/sdk` team to ensure the setting works correctly.

## Test plan
- [x] Verify CODEOWNERS file syntax is valid