### PR TITLE
Pin mise install with SHA256 verification

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -8,6 +8,22 @@ filters: &filters
     only: /.*/
 
 jobs:
+  test-install-mise:
+    macos:
+      xcode: 16.4.0
+    resource_class: m4pro.medium
+    steps:
+      - checkout
+      - <orb-name>/install-mise
+      - run:
+          name: Verify mise installation and persisted PATH
+          # Intentionally does not re-export PATH: this job verifies that
+          # install-mise persists the mise binary path to BASH_ENV so that
+          # subsequent run steps can find it.
+          command: |
+            mise --version
+            which mise
+
   test-install-tuist:
     macos:
       xcode: 16.4.0
@@ -105,6 +121,10 @@ workflows:
     jobs:
       - orb-tools/pack:
           filters: *filters
+      - test-install-mise:
+          requires:
+            - orb-tools/pack
+          filters: *filters
       - test-install-tuist:
           requires:
             - orb-tools/pack
@@ -148,6 +168,7 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
+            - test-install-mise
             - test-install-tuist
             - test-install-public-api-diff
             - test-install-maestro

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -10,7 +10,7 @@ filters: &filters
 jobs:
   test-install-mise:
     macos:
-      xcode: 16.4.0
+      xcode: 26.3.0
     resource_class: m4pro.medium
     steps:
       - checkout
@@ -26,7 +26,7 @@ jobs:
 
   test-install-tuist:
     macos:
-      xcode: 16.4.0
+      xcode: 26.3.0
     resource_class: m4pro.medium
     steps:
       - checkout
@@ -39,7 +39,7 @@ jobs:
 
   test-install-public-api-diff:
     macos:
-      xcode: 16.4.0
+      xcode: 26.3.0
     resource_class: m4pro.medium
     steps:
       - checkout
@@ -53,7 +53,7 @@ jobs:
 
   test-install-maestro:
     macos:
-      xcode: 16.4.0
+      xcode: 26.3.0
     resource_class: m4pro.medium
     steps:
       - checkout
@@ -65,7 +65,7 @@ jobs:
 
   test-install-swiftlint:
     macos:
-      xcode: 16.4.0
+      xcode: 26.3.0
     resource_class: m4pro.medium
     steps:
       - checkout
@@ -78,7 +78,7 @@ jobs:
 
   test-install-xcodes:
     macos:
-      xcode: 16.4.0
+      xcode: 26.3.0
     resource_class: m4pro.medium
     steps:
       - checkout
@@ -91,7 +91,7 @@ jobs:
 
   test-install-xcbeautify:
     macos:
-      xcode: 16.4.0
+      xcode: 26.3.0
     resource_class: m4pro.medium
     steps:
       - checkout
@@ -105,7 +105,7 @@ jobs:
 
   test-install-xcbeautify-from-mise-toml:
     macos:
-      xcode: 16.4.0
+      xcode: 26.3.0
     resource_class: m4pro.medium
     steps:
       - checkout

--- a/src/commands/install-mise.yml
+++ b/src/commands/install-mise.yml
@@ -1,0 +1,8 @@
+description: >
+  Installs a pinned version of the mise tool version manager, verifying the
+  downloaded archive against a known SHA256. Used as a prerequisite step by
+  install-tuist and install-swiftlint.
+steps:
+  - run:
+      name: Install mise
+      command: <<include(scripts/install-mise.sh)>>

--- a/src/commands/install-swiftlint.yml
+++ b/src/commands/install-swiftlint.yml
@@ -1,8 +1,9 @@
 description: >
   Installs mise tool version manager and SwiftLint (reads from .mise.toml)
 steps:
+  - install-mise
   - run:
-      name: Install mise and SwiftLint
+      name: Install SwiftLint
       command: <<include(scripts/install-swiftlint.sh)>>
 
 

--- a/src/commands/install-tuist.yml
+++ b/src/commands/install-tuist.yml
@@ -1,6 +1,7 @@
 description: >
   Installs mise tool version manager and Tuist (reads from .mise.toml)
 steps:
+  - install-mise
   - run:
-      name: Install mise and Tuist
+      name: Install Tuist
       command: <<include(scripts/install-tuist.sh)>>

--- a/src/commands/install-xcbeautify.yml
+++ b/src/commands/install-xcbeautify.yml
@@ -7,8 +7,9 @@ parameters:
     default: ""
     description: Version of xcbeautify to install. If empty, reads from mise.toml.
 steps:
+  - install-mise
   - run:
-      name: Install mise and xcbeautify
+      name: Install xcbeautify
       command: <<include(scripts/install-xcbeautify.sh)>>
       environment:
         XCBEAUTIFY_VERSION: << parameters.version >>

--- a/src/commands/install-xcodes.yml
+++ b/src/commands/install-xcodes.yml
@@ -1,6 +1,7 @@
 description: >
   Installs mise tool version manager and xcodes (reads from .mise.toml)
 steps:
+  - install-mise
   - run:
-      name: Install mise and xcodes
+      name: Install xcodes
       command: <<include(scripts/install-xcodes.sh)>>

--- a/src/scripts/install-mise.sh
+++ b/src/scripts/install-mise.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pinned mise version and SHA256 checksums for the release artifacts.
+# Bump all three values together when upgrading. See:
+#   https://github.com/jdx/mise/releases
+#   https://github.com/jdx/mise/releases/download/${MISE_VERSION}/SHASUMS256.txt
+MISE_VERSION="v2026.4.19"
+MISE_SHA256_MACOS_ARM64="0785176288afc613cc152956bca905b7a47b91232f1b360fa9136e594af1c593"
+MISE_SHA256_MACOS_X64="ce274ebeb8762e059c171fca1d0a7d8170f9870617b8defb7f2ed5ac798f9afb"
+
+export PATH="$HOME/.local/bin:$PATH"
+
+installed_version=""
+if command -v mise &> /dev/null; then
+    installed_version="$(mise --version 2>/dev/null | awk '{print $1}' || true)"
+fi
+
+if [ "$installed_version" = "${MISE_VERSION#v}" ]; then
+    echo "mise ${MISE_VERSION} already installed, skipping download."
+else
+    os="$(uname -s)"
+    arch="$(uname -m)"
+    case "$os/$arch" in
+        Darwin/arm64)
+            artifact="macos-arm64"
+            expected_sha="$MISE_SHA256_MACOS_ARM64"
+            ;;
+        Darwin/x86_64)
+            artifact="macos-x64"
+            expected_sha="$MISE_SHA256_MACOS_X64"
+            ;;
+        *)
+            echo "Unsupported platform: $os/$arch. install-mise.sh supports macOS only." >&2
+            exit 1
+            ;;
+    esac
+
+    tarball="mise-${MISE_VERSION}-${artifact}.tar.gz"
+    url="https://github.com/jdx/mise/releases/download/${MISE_VERSION}/${tarball}"
+
+    echo "Installing mise ${MISE_VERSION} (${artifact})..."
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    curl -fsSL -o "$tmpdir/mise.tar.gz" "$url"
+    echo "${expected_sha}  $tmpdir/mise.tar.gz" | shasum -a 256 -c -
+    mkdir -p "$HOME/.local"
+    tar xzf "$tmpdir/mise.tar.gz" -C "$HOME/.local" --strip-components=1
+fi
+
+# Activate mise (includes env, shims, etc.)
+eval "$(mise activate bash)"
+
+# Add shims to PATH (required in CI)
+export PATH="$HOME/.local/share/mise/shims:$PATH"
+
+# Persist PATH changes to BASH_ENV for subsequent CircleCI steps.
+echo "export PATH=\"\$HOME/.local/share/mise/shims:\$PATH\"" >> "$BASH_ENV"

--- a/src/scripts/install-mise.sh
+++ b/src/scripts/install-mise.sh
@@ -54,5 +54,6 @@ eval "$(mise activate bash)"
 # Add shims to PATH (required in CI)
 export PATH="$HOME/.local/share/mise/shims:$PATH"
 
-# Persist PATH changes to BASH_ENV for subsequent CircleCI steps.
-echo "export PATH=\"\$HOME/.local/share/mise/shims:\$PATH\"" >> "$BASH_ENV"
+# Persist PATH changes to BASH_ENV so mise and its shims are available in
+# subsequent CircleCI run steps (each step starts a fresh shell).
+echo "export PATH=\"\$HOME/.local/bin:\$HOME/.local/share/mise/shims:\$PATH\"" >> "$BASH_ENV"

--- a/src/scripts/install-swiftlint.sh
+++ b/src/scripts/install-swiftlint.sh
@@ -1,37 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Add mise to PATH
-export PATH="$HOME/.local/bin:$PATH"
-
-# Install mise if not already installed
-if command -v mise &> /dev/null; then
-    echo "mise is already installed, skipping installation..."
-else
-    echo "Installing mise..."
-    curl https://mise.run | sh
-fi
-
-# Activate mise (includes env, shims, etc.)
-eval "$(mise activate bash)"
-
-# Add shims to PATH (required in CI)
-export PATH="$HOME/.local/share/mise/shims:$PATH"
-
-# Optional: Ensure swiftlint plugin is installed
+# mise is installed by the install-mise command in this orb; assume it is on PATH.
 mise plugins install swiftlint
 
-# Check if mise.toml exists
 if [ ! -f "mise.toml" ]; then
     echo "❌ mise.toml not found. Please create a mise.toml file with swiftlint version specified."
     exit 1
 fi
 
-# Install tools
 mise install
 
-# Verify swiftlint
 swiftlint version || { echo "❌ SwiftLint did not install properly."; exit 1; }
 
 echo "✅ SwiftLint installation completed"
-

--- a/src/scripts/install-tuist.sh
+++ b/src/scripts/install-tuist.sh
@@ -1,40 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Add mise to PATH
-export PATH="$HOME/.local/bin:$PATH"
-
-# Install mise if not already installed
-if command -v mise &> /dev/null; then
-    echo "mise is already installed, skipping installation..."
-else
-    echo "Installing mise..."
-    curl https://mise.run | sh
-fi
-
-# Activate mise (includes env, shims, etc.)
-eval "$(mise activate bash)"
-
-# Add shims to PATH (required in CI)
-export PATH="$HOME/.local/share/mise/shims:$PATH"
-
-# Persist PATH changes to BASH_ENV for subsequent CircleCI steps
-# This ensures tuist (and other mise-installed tools) are available in subsequent steps
-echo "export PATH=\"\$HOME/.local/share/mise/shims:\$PATH\"" >> "$BASH_ENV"
-
-# Optional: Ensure tuist plugin is installed
+# mise is installed by the install-mise command in this orb; assume it is on PATH.
 mise plugins install tuist
 
-# Check if mise.toml exists
 if [ ! -f "mise.toml" ]; then
     echo "❌ mise.toml not found. Please create a mise.toml file with tuist version specified."
     exit 1
 fi
 
-# Install tools
 mise install
 
-# Verify tuist
 tuist version || { echo "❌ Tuist did not install properly."; exit 1; }
 
-echo "✅ Tuist installation completed" 
+echo "✅ Tuist installation completed"

--- a/src/scripts/install-xcbeautify.sh
+++ b/src/scripts/install-xcbeautify.sh
@@ -4,24 +4,7 @@ set -euo pipefail
 # Get version from environment variable (empty string means not provided)
 VERSION=${XCBEAUTIFY_VERSION:-}
 
-# Add mise to PATH
-export PATH="$HOME/.local/bin:$PATH"
-
-# Install mise if not already installed
-if command -v mise &> /dev/null; then
-    echo "mise is already installed, skipping installation..."
-else
-    echo "Installing mise..."
-    curl https://mise.run | sh
-fi
-
-# Activate mise (includes env, shims, etc.)
-eval "$(mise activate bash)"
-
-# Add shims to PATH (required in CI)
-export PATH="$HOME/.local/share/mise/shims:$PATH"
-
-# Install xcbeautify plugin from asdf-xcbeautify
+# mise is installed by the install-mise command in this orb; assume it is on PATH.
 mise plugins install xcbeautify https://github.com/mise-plugins/asdf-xcbeautify.git
 
 # Install xcbeautify - use parameter if provided, otherwise use mise.toml
@@ -30,7 +13,6 @@ if [ -n "$VERSION" ]; then
     mise install "xcbeautify@$VERSION"
     mise use -g "xcbeautify@$VERSION"
 else
-    # Check if mise.toml exists
     if [ ! -f "mise.toml" ]; then
         echo "❌ No version parameter provided and mise.toml not found."
         echo "Please either pass a version parameter or create a mise.toml file with xcbeautify version specified."
@@ -40,7 +22,6 @@ else
     mise install
 fi
 
-# Verify xcbeautify
 xcbeautify --version || { echo "❌ xcbeautify did not install properly."; exit 1; }
 
 echo "✅ xcbeautify installation completed"

--- a/src/scripts/install-xcodes.sh
+++ b/src/scripts/install-xcodes.sh
@@ -1,36 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Add mise to PATH
-export PATH="$HOME/.local/bin:$PATH"
-
-# Install mise if not already installed
-if command -v mise &> /dev/null; then
-    echo "mise is already installed, skipping installation..."
-else
-    echo "Installing mise..."
-    curl https://mise.run | sh
-fi
-
-# Activate mise (includes env, shims, etc.)
-eval "$(mise activate bash)"
-
-# Add shims to PATH (required in CI)
-export PATH="$HOME/.local/share/mise/shims:$PATH"
-
-# Install xcodes plugin from asdf-xcodes
+# mise is installed by the install-mise command in this orb; assume it is on PATH.
 mise plugins install xcodes https://github.com/younke/asdf-xcodes.git
 
-# Check if mise.toml exists
 if [ ! -f "mise.toml" ]; then
     echo "❌ mise.toml not found. Please create a mise.toml file with xcodes version specified."
     exit 1
 fi
 
-# Install tools
 mise install
 
-# Verify xcodes
 xcodes version || { echo "❌ xcodes did not install properly."; exit 1; }
 
 echo "✅ xcodes installation completed"


### PR DESCRIPTION
Replaces `curl https://mise.run | sh` across the orb with a pinned GitHub release verified by SHA256. The current install is unauthenticated remote code execution on every CI run.

## What changes

- New `install-mise` command is the single install path; `install-tuist`, `install-swiftlint`, `install-xcodes`, `install-xcbeautify` call it first.
- `install-mise.sh` pins `v2026.4.19` with SHA256s for `macos-arm64` and `macos-x64`. Tarball is downloaded, checksummed with `shasum -a 256 -c -`, then extracted.
- Early-exit when the pinned version is already installed, so chained installers download mise once per job.

## Why not brew

Brew can't pin exact versions of `tuist`/`swiftlint` (no `@x.y` formulae, `brew pin` only blocks upgrades on already-installed formulae — useless in CI), so installing them through brew would drop the reproducibility `mise.toml` gives us today. Pinned release + SHA gives stronger guarantees than `brew install mise` with comparable effort.

## Updating mise

Bump three constants at the top of `src/scripts/install-mise.sh`:

1. `MISE_VERSION` — pick a release from https://github.com/jdx/mise/releases.
2. `MISE_SHA256_MACOS_ARM64` / `MISE_SHA256_MACOS_X64` — grab from:
   ```sh
   curl -fsSL https://github.com/jdx/mise/releases/download/${MISE_VERSION}/SHASUMS256.txt \
     | grep -E 'macos-(arm64|x64)\.tar\.gz$'
   ```

Manual for now; we can likely automate this in the future via a Renovate custom manager for the version and a `postUpgradeTasks` hook (or a helper script) to refresh the SHAs in the same PR.