### PR TITLE
Add install-sdkman command with pinned, SHA256-verified install

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -24,6 +24,23 @@ jobs:
             mise --version
             which mise
 
+  test-install-sdkman:
+    macos:
+      xcode: 26.3.0
+    resource_class: m4pro.medium
+    steps:
+      - checkout
+      - <orb-name>/install-sdkman
+      - run:
+          name: Verify SDKMAN installation and persisted shell init
+          # Intentionally does not source sdkman-init.sh manually: this job
+          # verifies that install-sdkman persists $SDKMAN_DIR and the source
+          # line to $BASH_ENV so the `sdk` shell function is available in
+          # subsequent run steps.
+          command: |
+            sdk version | tee /tmp/sdk-version.txt
+            grep -q "SDKMAN 5.22.5" /tmp/sdk-version.txt
+
   test-install-tuist:
     macos:
       xcode: 26.3.0
@@ -125,6 +142,10 @@ workflows:
           requires:
             - orb-tools/pack
           filters: *filters
+      - test-install-sdkman:
+          requires:
+            - orb-tools/pack
+          filters: *filters
       - test-install-tuist:
           requires:
             - orb-tools/pack
@@ -169,6 +190,7 @@ workflows:
           requires:
             - orb-tools/pack
             - test-install-mise
+            - test-install-sdkman
             - test-install-tuist
             - test-install-public-api-diff
             - test-install-maestro

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -47,10 +47,16 @@ jobs:
           # copy of the script and assert the install exits non-zero before
           # extracting anything. Uses a separate $SDKMAN_DIR so the real
           # install above is left intact.
+          #
+          # BASH_ENV must be cleared for the bad-install invocation: every
+          # non-interactive bash on CircleCI sources $BASH_ENV at startup,
+          # and the previous install-sdkman step appended `export
+          # SDKMAN_DIR=...` to it. Without this, the subprocess re-sources
+          # the real $SDKMAN_DIR and skips the download via early-exit.
           command: |
             sed 's/SDKMAN_CLI_SHA256="[^"]*"/SDKMAN_CLI_SHA256="0000000000000000000000000000000000000000000000000000000000000000"/' \
               src/scripts/install-sdkman.sh > /tmp/bad-install-sdkman.sh
-            if SDKMAN_DIR="$HOME/.sdkman-bad" bash /tmp/bad-install-sdkman.sh; then
+            if (unset BASH_ENV; SDKMAN_DIR="$HOME/.sdkman-bad" bash /tmp/bad-install-sdkman.sh); then
                 echo "ERROR: install with bad SHA should have failed but succeeded" >&2
                 exit 1
             fi

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
   test-install-sdkman:
     macos:
-      xcode: 26.3.0
+      xcode: 26.4.1
     resource_class: m4pro.medium
     steps:
       - checkout
@@ -38,8 +38,23 @@ jobs:
           # line to $BASH_ENV so the `sdk` shell function is available in
           # subsequent run steps.
           command: |
+            expected="$(grep -oE 'SDKMAN_VERSION="[^"]+"' src/scripts/install-sdkman.sh | sed -E 's/SDKMAN_VERSION="(.*)"/\1/')"
             sdk version | tee /tmp/sdk-version.txt
-            grep -q "SDKMAN 5.22.5" /tmp/sdk-version.txt
+            grep -q "SDKMAN ${expected}" /tmp/sdk-version.txt
+      - run:
+          name: Verify SHA-mismatch fails the install
+          # Sanity-check the integrity gate: substitute a bogus SHA into a
+          # copy of the script and assert the install exits non-zero before
+          # extracting anything. Uses a separate $SDKMAN_DIR so the real
+          # install above is left intact.
+          command: |
+            sed 's/SDKMAN_CLI_SHA256="[^"]*"/SDKMAN_CLI_SHA256="0000000000000000000000000000000000000000000000000000000000000000"/' \
+              src/scripts/install-sdkman.sh > /tmp/bad-install-sdkman.sh
+            if SDKMAN_DIR="$HOME/.sdkman-bad" bash /tmp/bad-install-sdkman.sh; then
+                echo "ERROR: install with bad SHA should have failed but succeeded" >&2
+                exit 1
+            fi
+            echo "OK: SHA-mismatch correctly rejected"
 
   test-install-tuist:
     macos:

--- a/src/commands/install-sdkman.yml
+++ b/src/commands/install-sdkman.yml
@@ -1,0 +1,8 @@
+description: >
+  Installs SDKMAN from a pinned, SHA256-verified GitHub release.
+  Persists $SDKMAN_DIR and the sdkman-init source line to $BASH_ENV so the
+  `sdk` shell function is available in subsequent run steps.
+steps:
+  - run:
+      name: Install SDKMAN
+      command: <<include(scripts/install-sdkman.sh)>>

--- a/src/scripts/install-sdkman.sh
+++ b/src/scripts/install-sdkman.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pinned SDKMAN CLI version and SHA256 of its release artifact.
+# Bump both values together when upgrading. See:
+#   https://github.com/sdkman/sdkman-cli/releases
+#   https://github.com/sdkman/sdkman-cli/releases/download/${SDKMAN_VERSION}/checksums_sha256.txt
+SDKMAN_VERSION="5.22.5"
+SDKMAN_CLI_SHA256="301de44c2455c061c8ac40fae194dd9287251115e34f8d86de68914510eb12c9"
+
+SDKMAN_DIR="${SDKMAN_DIR:-$HOME/.sdkman}"
+
+if [ -f "$SDKMAN_DIR/var/version" ] && [ "$(cat "$SDKMAN_DIR/var/version")" = "$SDKMAN_VERSION" ]; then
+    echo "SDKMAN ${SDKMAN_VERSION} already installed at ${SDKMAN_DIR}, skipping download."
+else
+    case "$(uname -s)/$(uname -m)" in
+        Linux/x86_64)  platform="linuxx64" ;;
+        Linux/aarch64) platform="linuxarm64" ;;
+        Darwin/arm64)  platform="darwinarm64" ;;
+        Darwin/x86_64) platform="darwinx64" ;;
+        *)
+            echo "Unsupported platform: $(uname -s)/$(uname -m)." >&2
+            exit 1
+            ;;
+    esac
+
+    url="https://github.com/sdkman/sdkman-cli/releases/download/${SDKMAN_VERSION}/sdkman-cli-${SDKMAN_VERSION}.zip"
+
+    echo "Installing SDKMAN ${SDKMAN_VERSION} (${platform}) into ${SDKMAN_DIR}..."
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    curl -fsSL -o "$tmpdir/sdkman-cli.zip" "$url"
+    echo "${SDKMAN_CLI_SHA256}  $tmpdir/sdkman-cli.zip" | shasum -a 256 -c -
+
+    rm -rf "$SDKMAN_DIR"
+    mkdir -p "$SDKMAN_DIR"
+    unzip -q "$tmpdir/sdkman-cli.zip" -d "$tmpdir/extract"
+    cp -R "$tmpdir/extract/sdkman-${SDKMAN_VERSION}/." "$SDKMAN_DIR/"
+    mkdir -p "$SDKMAN_DIR/libexec" "$SDKMAN_DIR/etc" "$SDKMAN_DIR/var" \
+             "$SDKMAN_DIR/candidates" "$SDKMAN_DIR/tmp" "$SDKMAN_DIR/ext"
+
+    # Write the config the upstream installer would write, with two CI-friendly
+    # tweaks: rcupdate=false (we manage shell init ourselves) and
+    # selfupdate=false (we never want SDKMAN to silently upgrade itself in CI).
+    # sdkman_native_enable=false because we install only the script CLI,
+    # not the optional Rust native binary; sdkman falls back to shell impls.
+    cat > "$SDKMAN_DIR/etc/config" <<'EOF'
+sdkman_auto_answer=false
+sdkman_auto_complete=true
+sdkman_auto_env=false
+sdkman_auto_update=false
+sdkman_beta_channel=false
+sdkman_checksum_enable=true
+sdkman_colour_enable=true
+sdkman_curl_connect_timeout=7
+sdkman_curl_max_time=10
+sdkman_debug_mode=false
+sdkman_healthcheck_enable=false
+sdkman_insecure_ssl=false
+sdkman_native_enable=false
+sdkman_rosetta2_compatible=false
+sdkman_selfupdate_enable=false
+EOF
+
+    echo "$platform" > "$SDKMAN_DIR/var/platform"
+    echo "$SDKMAN_VERSION" > "$SDKMAN_DIR/var/version"
+    # var/candidates is a CSV cache of valid candidate names. SDKMAN refuses
+    # to run any command if the file is empty ("Cache is corrupt"), so we
+    # populate it from api.sdkman.io the same way the upstream installer
+    # does. The contents are non-sensitive (a list of names like
+    # "java,kotlin,gradle,…") and any tampering can't widen what `sdk env
+    # install` will install — that's controlled by .sdkmanrc.
+    curl -fsSL "https://api.sdkman.io/2/candidates/all" \
+        -o "$SDKMAN_DIR/var/candidates"
+fi
+
+# Persist sdkman init for subsequent CircleCI run steps (each step is a fresh shell).
+echo "export SDKMAN_DIR=\"${SDKMAN_DIR}\"" >> "$BASH_ENV"
+echo "source \"${SDKMAN_DIR}/bin/sdkman-init.sh\"" >> "$BASH_ENV"

--- a/src/scripts/install-sdkman.sh
+++ b/src/scripts/install-sdkman.sh
@@ -29,7 +29,8 @@ else
     echo "Installing SDKMAN ${SDKMAN_VERSION} (${platform}) into ${SDKMAN_DIR}..."
     tmpdir="$(mktemp -d)"
     trap 'rm -rf "$tmpdir"' EXIT
-    curl -fsSL -o "$tmpdir/sdkman-cli.zip" "$url"
+    curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 --retry-connrefused \
+        -o "$tmpdir/sdkman-cli.zip" "$url"
     echo "${SDKMAN_CLI_SHA256}  $tmpdir/sdkman-cli.zip" | shasum -a 256 -c -
 
     rm -rf "$SDKMAN_DIR"
@@ -39,11 +40,16 @@ else
     mkdir -p "$SDKMAN_DIR/libexec" "$SDKMAN_DIR/etc" "$SDKMAN_DIR/var" \
              "$SDKMAN_DIR/candidates" "$SDKMAN_DIR/tmp" "$SDKMAN_DIR/ext"
 
-    # Write the config the upstream installer would write, with two CI-friendly
-    # tweaks: rcupdate=false (we manage shell init ourselves) and
-    # selfupdate=false (we never want SDKMAN to silently upgrade itself in CI).
-    # sdkman_native_enable=false because we install only the script CLI,
-    # not the optional Rust native binary; sdkman falls back to shell impls.
+    # Write a CI-friendly SDKMAN config:
+    # - sdkman_auto_update / sdkman_selfupdate_enable = false: SDKMAN must
+    #   never silently upgrade itself in CI; the version is pinned above.
+    # - sdkman_auto_env = false: don't auto-source .sdkmanrc on cd; consumers
+    #   invoke `sdk env install` explicitly.
+    # - sdkman_native_enable = false: we install only the script CLI, not the
+    #   optional Rust native binary, so sdkman must fall back to shell impls
+    #   for commands that have native counterparts.
+    # - sdkman_healthcheck_enable = false: skip the api.sdkman.io probe that
+    #   runs on every shell init.
     cat > "$SDKMAN_DIR/etc/config" <<'EOF'
 sdkman_auto_answer=false
 sdkman_auto_complete=true
@@ -70,7 +76,8 @@ EOF
     # does. The contents are non-sensitive (a list of names like
     # "java,kotlin,gradle,…") and any tampering can't widen what `sdk env
     # install` will install — that's controlled by .sdkmanrc.
-    curl -fsSL "https://api.sdkman.io/2/candidates/all" \
+    curl -fsSL --connect-timeout 10 --max-time 30 --retry 3 --retry-connrefused \
+        "https://api.sdkman.io/2/candidates/all" \
         -o "$SDKMAN_DIR/var/candidates"
 fi
 


### PR DESCRIPTION
Adds a new `install-sdkman` orb command that replaces the unauthenticated `curl https://get.sdkman.io | bash` install pattern duplicated across the SDK repos.

Mirrors the security model from #53 (the `mise` PR) for SDKMAN.

## What changes

- New `install-sdkman` command + script under `src/commands/install-sdkman.yml` and `src/scripts/install-sdkman.sh`.
- `install-sdkman.sh` pins `SDKMAN_VERSION="5.22.5"` with the SHA256 of `sdkman-cli-5.22.5.zip`. The artifact is downloaded straight from `github.com/sdkman/sdkman-cli/releases`, checksummed with `shasum -a 256 -c -`, then extracted into `$SDKMAN_DIR`.
- Early-exits if `$SDKMAN_DIR/var/version` already matches the pinned version.
- Installs only the script CLI (sets `sdkman_native_enable=false`) — sdkman falls back to shell impls for commands that have native counterparts. One artifact, one SHA, no `api.sdkman.io` broker hop for the SDKMAN binary itself. (The post-install `var/candidates` cache is still fetched from `api.sdkman.io` — the upstream installer does the same, and the contents are a non-sensitive name list that can't widen what `sdk env install` installs.)
- Persists `$SDKMAN_DIR` and the `source sdkman-init.sh` line to `$BASH_ENV` so the `sdk` shell function is available in subsequent run steps.
- New `test-install-sdkman` job in `.circleci/test-deploy.yml` verifies the install + that BASH_ENV persistence makes `sdk` available in a follow-up step. Wired into the `orb-tools/publish` `requires` gate.

## What this still doesn't cover

`sdk env install` (which consumers run after this command) still hits `api.sdkman.io` to download the JDK. That download isn't SHA-pinned by us. Locking the JDK install integrity is a separate effort and out of scope here — this PR matches the scope of #53 (harden the package manager install itself).

## Updating SDKMAN

Bump two constants at the top of `src/scripts/install-sdkman.sh`:

1. `SDKMAN_VERSION` — pick a release from https://github.com/sdkman/sdkman-cli/releases.
2. `SDKMAN_CLI_SHA256` — grab from:
   ```sh
   curl -fsSL https://github.com/sdkman/sdkman-cli/releases/download/${SDKMAN_VERSION}/checksums_sha256.txt
   ```

## Validation

- Smoke-tested locally: install + SHA verification + early-exit + SHA-mismatch failure path all behave correctly.
- Validated end-to-end on CI by consuming the dev-published version of this PR in [RevenueCat/purchases-android#3403](https://github.com/RevenueCat/purchases-android/pull/3403). Once this PR ships a tagged release, the downstream PR will bump from the dev pin to the tagged version.