### PR TITLE
Pin Maestro install with SHA256 verification

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -68,6 +68,26 @@ jobs:
             expected="$(grep -oE 'MAESTRO_VERSION="[^"]+"' src/scripts/install-maestro.sh | sed -E 's/MAESTRO_VERSION="(.*)"/\1/')"
             maestro --version | tee /tmp/maestro-version.txt
             grep -q "${expected}" /tmp/maestro-version.txt
+      - run:
+          name: Verify SHA-mismatch fails the install
+          # Sanity-check the integrity gate: substitute a bogus SHA into a
+          # copy of the script and assert the install exits non-zero before
+          # extracting anything. Uses a separate $MAESTRO_DIR so the real
+          # install above is left intact.
+          #
+          # BASH_ENV must be cleared for the bad-install invocation: every
+          # non-interactive bash on CircleCI sources $BASH_ENV at startup,
+          # and the previous install-maestro step appended `export PATH=...`
+          # to it. Without this, the subprocess re-sources the real
+          # $MAESTRO_DIR and skips the download via early-exit.
+          command: |
+            sed 's/MAESTRO_SHA256="[^"]*"/MAESTRO_SHA256="0000000000000000000000000000000000000000000000000000000000000000"/' \
+              src/scripts/install-maestro.sh > /tmp/bad-install-maestro.sh
+            if (unset BASH_ENV; MAESTRO_DIR="$HOME/.maestro-bad" bash /tmp/bad-install-maestro.sh); then
+                echo "ERROR: install with bad SHA should have failed but succeeded" >&2
+                exit 1
+            fi
+            echo "OK: SHA-mismatch correctly rejected"
 
   test-install-swiftlint:
     macos:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -65,8 +65,9 @@ jobs:
           # run steps can invoke `maestro` directly. Also asserts the pinned
           # version was actually installed.
           command: |
+            expected="$(grep -oE 'MAESTRO_VERSION="[^"]+"' src/scripts/install-maestro.sh | sed -E 's/MAESTRO_VERSION="(.*)"/\1/')"
             maestro --version | tee /tmp/maestro-version.txt
-            grep -q "2.5.0" /tmp/maestro-version.txt
+            grep -q "${expected}" /tmp/maestro-version.txt
 
   test-install-swiftlint:
     macos:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -59,9 +59,14 @@ jobs:
       - checkout
       - <orb-name>/install-maestro
       - run:
-          name: Verify Maestro installation
+          name: Verify Maestro installation and persisted PATH
+          # Intentionally does not re-export PATH: this job verifies that
+          # install-maestro persists ~/.maestro/bin to BASH_ENV so subsequent
+          # run steps can invoke `maestro` directly. Also asserts the pinned
+          # version was actually installed.
           command: |
-            maestro --version
+            maestro --version | tee /tmp/maestro-version.txt
+            grep -q "2.5.0" /tmp/maestro-version.txt
 
   test-install-swiftlint:
     macos:

--- a/src/commands/install-maestro.yml
+++ b/src/commands/install-maestro.yml
@@ -1,5 +1,7 @@
 description: >
-  Installs Maestro tool for running UI tests
+  Installs Maestro CLI from a pinned, SHA256-verified GitHub release.
+  Persists the Maestro bin directory to $PATH via $BASH_ENV so subsequent
+  run steps can invoke `maestro` directly.
 steps:
   - run:
       name: Install Maestro

--- a/src/scripts/install-maestro.sh
+++ b/src/scripts/install-maestro.sh
@@ -36,3 +36,8 @@ fi
 
 # Persist PATH for subsequent CircleCI run steps (each step starts a fresh shell).
 echo "export PATH=\"${MAESTRO_DIR}/bin:\$PATH\"" >> "$BASH_ENV"
+
+# Suppress maestro's per-invocation update check against mobile.dev. The
+# install above is version-pinned and SHA-verified; we don't want CI runs
+# phoning out for a check that can't change what gets executed anyway.
+echo 'export MAESTRO_DISABLE_UPDATE_CHECK=true' >> "$BASH_ENV"

--- a/src/scripts/install-maestro.sh
+++ b/src/scripts/install-maestro.sh
@@ -1,14 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install Maestro
-echo "Installing maestro..."
-curl -Ls "https://get.maestro.mobile.dev" | bash
+# Pinned Maestro CLI version and SHA256 of its release artifact.
+# Bump both values together when upgrading. See:
+#   https://github.com/mobile-dev-inc/maestro/releases
+#   https://github.com/mobile-dev-inc/maestro/releases/download/cli-${MAESTRO_VERSION}/checksums_sha256.txt
+MAESTRO_VERSION="2.5.0"
+MAESTRO_SHA256="9c9a7617b47e21d4a9add205e0a2ec45f71f9fb0cb651051281afbc3f87158ea"
 
-# Add Maestro to PATH
-export PATH="$HOME/.maestro/bin:$PATH"
+MAESTRO_DIR="${MAESTRO_DIR:-$HOME/.maestro}"
 
-# Verify Maestro installation
-maestro --version || { echo "❌ Maestro did not install properly."; exit 1; }
+# Sentinel file used for the early-exit check below. Avoids depending on
+# `maestro --version` output (would also require Java on PATH, and the
+# format isn't a stable contract).
+version_marker="$MAESTRO_DIR/.installed-version"
 
-echo "✅ Maestro installation completed" 
+if [ -f "$version_marker" ] && [ "$(cat "$version_marker")" = "$MAESTRO_VERSION" ]; then
+    echo "Maestro ${MAESTRO_VERSION} already installed at ${MAESTRO_DIR}, skipping download."
+else
+    url="https://github.com/mobile-dev-inc/maestro/releases/download/cli-${MAESTRO_VERSION}/maestro.zip"
+
+    echo "Installing Maestro ${MAESTRO_VERSION} into ${MAESTRO_DIR}..."
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    curl -fsSL -o "$tmpdir/maestro.zip" "$url"
+    echo "${MAESTRO_SHA256}  $tmpdir/maestro.zip" | shasum -a 256 -c -
+
+    rm -rf "$MAESTRO_DIR"
+    mkdir -p "$MAESTRO_DIR"
+    unzip -q "$tmpdir/maestro.zip" -d "$tmpdir/extract"
+    cp -R "$tmpdir/extract/maestro/." "$MAESTRO_DIR/"
+    echo "$MAESTRO_VERSION" > "$version_marker"
+fi
+
+# Persist PATH for subsequent CircleCI run steps (each step starts a fresh shell).
+echo "export PATH=\"${MAESTRO_DIR}/bin:\$PATH\"" >> "$BASH_ENV"

--- a/src/scripts/install-maestro.sh
+++ b/src/scripts/install-maestro.sh
@@ -26,10 +26,10 @@ else
     curl -fsSL -o "$tmpdir/maestro.zip" "$url"
     echo "${MAESTRO_SHA256}  $tmpdir/maestro.zip" | shasum -a 256 -c -
 
+    unzip -q "$tmpdir/maestro.zip" -d "$tmpdir"
     rm -rf "$MAESTRO_DIR"
-    mkdir -p "$MAESTRO_DIR"
-    unzip -q "$tmpdir/maestro.zip" -d "$tmpdir/extract"
-    cp -R "$tmpdir/extract/maestro/." "$MAESTRO_DIR/"
+    mkdir -p "$(dirname "$MAESTRO_DIR")"
+    mv "$tmpdir/maestro" "$MAESTRO_DIR"
     echo "$MAESTRO_VERSION" > "$version_marker"
 fi
 

--- a/src/scripts/install-maestro.sh
+++ b/src/scripts/install-maestro.sh
@@ -23,7 +23,8 @@ else
     echo "Installing Maestro ${MAESTRO_VERSION} into ${MAESTRO_DIR}..."
     tmpdir="$(mktemp -d)"
     trap 'rm -rf "$tmpdir"' EXIT
-    curl -fsSL -o "$tmpdir/maestro.zip" "$url"
+    curl -fsSL --connect-timeout 10 --max-time 300 --retry 3 --retry-connrefused \
+        -o "$tmpdir/maestro.zip" "$url"
     echo "${MAESTRO_SHA256}  $tmpdir/maestro.zip" | shasum -a 256 -c -
 
     unzip -q "$tmpdir/maestro.zip" -d "$tmpdir"


### PR DESCRIPTION
Replaces `curl https://get.maestro.mobile.dev | bash` in `install-maestro.sh` with a pinned GitHub release verified by SHA256. The current install is unauthenticated remote code execution on every CI run.

Follows the pattern from #53 (mise) and #55 (sdkman).

## What changes

- `install-maestro.sh` pins `MAESTRO_VERSION="2.5.0"` with the SHA256 of `maestro.zip`. The artifact is downloaded straight from `github.com/mobile-dev-inc/maestro/releases`, checksummed with `shasum -a 256 -c -`, then extracted into `$MAESTRO_DIR` (default `$HOME/.maestro`).
- Early-exits if a sentinel file at `$MAESTRO_DIR/.installed-version` already matches the pinned version. Avoids re-downloading the 213 MB artifact when a job has already run install-maestro. Uses a sentinel file rather than `maestro --version` so the check doesn't depend on Java being on PATH or on the `--version` output format.
- Persists `$MAESTRO_DIR/bin` to `$PATH` via `$BASH_ENV` so subsequent run steps can invoke `maestro` directly.
- Drops the post-install `maestro --version` self-check. Verification belongs in the test job (and `set -euo pipefail` already fails the script on any earlier error).
- Strengthens `test-install-maestro` to run `maestro --version` from a separate run step (verifies BASH_ENV PATH persistence) and grep the output for `2.5.0` (verifies the pinned version actually got installed).

## Updating Maestro

Bump two constants at the top of `src/scripts/install-maestro.sh`:

1. `MAESTRO_VERSION` — pick a release from https://github.com/mobile-dev-inc/maestro/releases.
2. `MAESTRO_SHA256` — grab from:
   ```sh
   curl -fsSL https://github.com/mobile-dev-inc/maestro/releases/download/cli-${MAESTRO_VERSION}/checksums_sha256.txt
   ```