### PR TITLE
Fix merge-release-pr job failing after a successful merge

### DIFF
--- a/src/scripts/merge-release-pr.sh
+++ b/src/scripts/merge-release-pr.sh
@@ -31,8 +31,6 @@ bundle exec fastlane run merge_pr \
 # off the end of the script does not source ~/.bash_logout, so the success path
 # does nothing here and simply lets the script end.
 if [ "${merge_exit_code}" -ne 0 ]; then
-    # The job fails on any non-zero exit, so the ~/.bash_logout caveat above is
-    # harmless here; the original code is logged so it isn't lost.
     if [ "${using_merge_queue}" = true ]; then
         echo "Merge queue enqueue failed (exit code ${merge_exit_code})."
         exit "${merge_exit_code}"

--- a/src/scripts/merge-release-pr.sh
+++ b/src/scripts/merge-release-pr.sh
@@ -32,9 +32,9 @@ bundle exec fastlane run merge_pr \
 # does nothing here and simply lets the script end.
 if [ "${merge_exit_code}" -ne 0 ]; then
     # The job fails on any non-zero exit, so the ~/.bash_logout caveat above is
-    # harmless on this failure path.
+    # harmless here; the original code is logged so it isn't lost.
     if [ "${using_merge_queue}" = true ]; then
-        echo "Merge queue enqueue failed."
+        echo "Merge queue enqueue failed (exit code ${merge_exit_code})."
         exit "${merge_exit_code}"
     fi
 

--- a/src/scripts/merge-release-pr.sh
+++ b/src/scripts/merge-release-pr.sh
@@ -23,35 +23,31 @@ bundle exec fastlane run merge_pr \
     merge_method:"${MERGE_METHOD}" \
     ${merge_queue_arg} || merge_exit_code=$?
 
-# This script runs in a login shell (bash --login) with `set -e`. Using the
-# `exit` builtin makes bash source ~/.bash_logout, whose default `clear_console`
-# command exits non-zero when there is no controlling TTY (as in CI). With
-# `set -e` still active that failure overrides our intended status, which would
-# turn a successful merge into a job failure. Disabling `set -e` here preserves
-# the `exit 0`. Paths that fall off the end of the script do not source
-# ~/.bash_logout, so they are unaffected.
-if [ "${merge_exit_code}" -eq 0 ]; then
-    set +e
-    exit 0
+# On success we must NOT call `exit` explicitly. This script runs in a login
+# shell (bash --login) and the `exit` builtin makes bash source ~/.bash_logout,
+# whose default `clear_console` command exits non-zero when there is no
+# controlling TTY (as in CI). With `set -e` still active that failure would
+# override our status and turn a successful merge into a job failure. Falling
+# off the end of the script does not source ~/.bash_logout, so the success path
+# does nothing here and simply lets the script end.
+if [ "${merge_exit_code}" -ne 0 ]; then
+    # The job fails on any non-zero exit, so the ~/.bash_logout caveat above is
+    # harmless here; the original code is logged so it isn't lost.
+    if [ "${using_merge_queue}" = true ]; then
+        echo "Merge queue enqueue failed (exit code ${merge_exit_code})."
+        exit "${merge_exit_code}"
+    fi
+
+    echo "Direct merge failed. Enabling auto-merge and updating branch..."
+
+    bundle exec fastlane run enable_auto_merge_for_pr \
+        repo_name:"${REPO_NAME}" \
+        branch:"${release_branch}" \
+        merge_method:"${MERGE_METHOD}"
+
+    bundle exec fastlane run update_pr_branch \
+        repo_name:"${REPO_NAME}" \
+        branch:"${release_branch}"
+
+    echo "Auto-merge enabled and branch updated. The PR will merge automatically once CI passes."
 fi
-
-# The job fails on any non-zero exit, so there's no need to disable `set -e`
-# here even though ~/.bash_logout may rewrite the exact code (see above). The
-# original code is logged below so it isn't lost.
-if [ "${using_merge_queue}" = true ]; then
-    echo "Merge queue enqueue failed (exit code ${merge_exit_code})."
-    exit "${merge_exit_code}"
-fi
-
-echo "Direct merge failed. Enabling auto-merge and updating branch..."
-
-bundle exec fastlane run enable_auto_merge_for_pr \
-    repo_name:"${REPO_NAME}" \
-    branch:"${release_branch}" \
-    merge_method:"${MERGE_METHOD}"
-
-bundle exec fastlane run update_pr_branch \
-    repo_name:"${REPO_NAME}" \
-    branch:"${release_branch}"
-
-echo "Auto-merge enabled and branch updated. The PR will merge automatically once CI passes."

--- a/src/scripts/merge-release-pr.sh
+++ b/src/scripts/merge-release-pr.sh
@@ -35,10 +35,11 @@ if [ "${merge_exit_code}" -eq 0 ]; then
     exit 0
 fi
 
-# A non-zero exit here fails the job regardless of whether ~/.bash_logout rewrites
-# the exact code, so there's no need to disable `set -e`.
+# The job fails on any non-zero exit, so there's no need to disable `set -e`
+# here even though ~/.bash_logout may rewrite the exact code (see above). The
+# original code is logged below so it isn't lost.
 if [ "${using_merge_queue}" = true ]; then
-    echo "Merge queue enqueue failed."
+    echo "Merge queue enqueue failed (exit code ${merge_exit_code})."
     exit "${merge_exit_code}"
 fi
 

--- a/src/scripts/merge-release-pr.sh
+++ b/src/scripts/merge-release-pr.sh
@@ -32,9 +32,9 @@ bundle exec fastlane run merge_pr \
 # does nothing here and simply lets the script end.
 if [ "${merge_exit_code}" -ne 0 ]; then
     # The job fails on any non-zero exit, so the ~/.bash_logout caveat above is
-    # harmless here; the original code is logged so it isn't lost.
+    # harmless on this failure path.
     if [ "${using_merge_queue}" = true ]; then
-        echo "Merge queue enqueue failed (exit code ${merge_exit_code})."
+        echo "Merge queue enqueue failed."
         exit "${merge_exit_code}"
     fi
 

--- a/src/scripts/merge-release-pr.sh
+++ b/src/scripts/merge-release-pr.sh
@@ -23,10 +23,20 @@ bundle exec fastlane run merge_pr \
     merge_method:"${MERGE_METHOD}" \
     ${merge_queue_arg} || merge_exit_code=$?
 
+# This script runs in a login shell (bash --login) with `set -e`. Using the
+# `exit` builtin makes bash source ~/.bash_logout, whose default `clear_console`
+# command exits non-zero when there is no controlling TTY (as in CI). With
+# `set -e` still active that failure overrides our intended status, which would
+# turn a successful merge into a job failure. Disabling `set -e` here preserves
+# the `exit 0`. Paths that fall off the end of the script do not source
+# ~/.bash_logout, so they are unaffected.
 if [ "${merge_exit_code}" -eq 0 ]; then
+    set +e
     exit 0
 fi
 
+# A non-zero exit here fails the job regardless of whether ~/.bash_logout rewrites
+# the exact code, so there's no need to disable `set -e`.
 if [ "${using_merge_queue}" = true ]; then
     echo "Merge queue enqueue failed."
     exit "${merge_exit_code}"


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

Restructure `merge-release-pr.sh` so the successful-merge path falls off the end of the script instead of calling `exit 0`.

## Motivation:

The job runs in a login shell (`bash --login`) with `set -e`. The `exit` builtin makes bash source `~/.bash_logout`, whose default `clear_console` exits non-zero with no TTY (as in CI); `set -e` then flips the status, failing the job even though the PR was already merged. Falling off the end of the script does not source `~/.bash_logout`, so the success path avoids it entirely.

A `set +e` before `exit 0` would also work but was deliberately avoided, to keep `set -e` protection intact rather than rely on a workaround. Confirmed in `cimg/ruby:3.2.0`: `exit 0` exits 1 while falling off the end exits 0.