### PR TITLE
update-error-codes: support multiple output files per platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Current development changes [ to be moved to release ]
+- `update-error-codes`: add `outputs` parameter (newline-delimited `source:destination` pairs)
+  so a platform can write more than one generated file (e.g. kmp native mappings, flutter
+  api_tester). The legacy single `output` parameter still works.
 
 ## [1.0.0] - 2021-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Current development changes [ to be moved to release ]
-- `update-error-codes`: add `outputs` parameter (newline-delimited `source:destination` pairs)
-  so a platform can write more than one generated file (e.g. kmp native mappings, flutter
-  api_tester). The legacy single `output` parameter still works.
 
 ## [1.0.0] - 2021-03-11
 

--- a/src/jobs/update-error-codes.yml
+++ b/src/jobs/update-error-codes.yml
@@ -12,18 +12,11 @@ parameters:
     description: "Generator platform: android, ios, js, kmp, flutter, or hybridCommon"
   outputs:
     type: string
-    default: ""
     description: >
       Newline-delimited `source:destination` pairs, one per generated file. `source` is the
       file name under the SSOT's generated/<platform>/ directory; `destination` is its
-      repo-root-relative path. Use this for platforms that emit more than one file (e.g. kmp,
-      flutter). When empty, falls back to the single `output` parameter.
-  output:
-    type: string
-    default: ""
-    description: >
-      Repo-root-relative path of the generated file to write. Legacy single-file form; prefer
-      `outputs`. Ignored when `outputs` is set.
+      repo-root-relative path. A platform may emit one file (e.g. android, ios, js) or several
+      (e.g. kmp, flutter).
   update_api_steps:
     type: steps
     default: []
@@ -46,13 +39,11 @@ steps:
       environment:
         PLATFORM: << parameters.platform >>
         OUTPUTS: << parameters.outputs >>
-        OUTPUT: << parameters.output >>
       command: <<include(scripts/copy-error-codes.sh)>>
   - run:
       name: Stop if generated files are unchanged
       environment:
         OUTPUTS: << parameters.outputs >>
-        OUTPUT: << parameters.output >>
       command: <<include(scripts/stop-if-error-codes-unchanged.sh)>>
   - steps: << parameters.update_api_steps >>
   - run:

--- a/src/jobs/update-error-codes.yml
+++ b/src/jobs/update-error-codes.yml
@@ -9,10 +9,21 @@ parameters:
     description: "Executor to run on. Defaults to a Ruby+Node Docker image; override for native toolchains (Android/iOS)."
   platform:
     type: string
-    description: "Generator platform: android, ios, or js"
+    description: "Generator platform: android, ios, js, kmp, flutter, or hybridCommon"
+  outputs:
+    type: string
+    default: ""
+    description: >
+      Newline-delimited `source:destination` pairs, one per generated file. `source` is the
+      file name under the SSOT's generated/<platform>/ directory; `destination` is its
+      repo-root-relative path. Use this for platforms that emit more than one file (e.g. kmp,
+      flutter). When empty, falls back to the single `output` parameter.
   output:
     type: string
-    description: "Repo-root-relative path of the generated file to write"
+    default: ""
+    description: >
+      Repo-root-relative path of the generated file to write. Legacy single-file form; prefer
+      `outputs`. Ignored when `outputs` is set.
   update_api_steps:
     type: steps
     default: []
@@ -34,11 +45,13 @@ steps:
       name: Copy error codes
       environment:
         PLATFORM: << parameters.platform >>
+        OUTPUTS: << parameters.outputs >>
         OUTPUT: << parameters.output >>
       command: <<include(scripts/copy-error-codes.sh)>>
   - run:
-      name: Stop if generated file is unchanged
+      name: Stop if generated files are unchanged
       environment:
+        OUTPUTS: << parameters.outputs >>
         OUTPUT: << parameters.output >>
       command: <<include(scripts/stop-if-error-codes-unchanged.sh)>>
   - steps: << parameters.update_api_steps >>

--- a/src/scripts/copy-error-codes.sh
+++ b/src/scripts/copy-error-codes.sh
@@ -1,12 +1,56 @@
 #!/usr/bin/env bash
+
+# OUTPUT and OUTPUTS are both injected via the job's `environment`; silence the
+# "OUTPUT may not be assigned, did you mean OUTPUTS" heuristic.
+# shellcheck disable=SC2153
 set -euo pipefail
 
-# Clones the error-codes SSOT repo and copies this platform's committed generated file.
-# The file under generated/<platform> is byte-identical to `pnpm generate` output
-# (enforced by the SSOT's golden test), so no JS toolchain is needed here.
-# Inputs (environment): PLATFORM (android|ios|js), OUTPUT (repo-root-relative destination).
+# Clones the error-codes SSOT repo and copies this platform's committed generated files.
+# Files under generated/<platform>/ are byte-identical to `pnpm generate` output (enforced by
+# the SSOT's golden test), so no JS toolchain is needed here.
+#
+# Inputs (environment):
+#   PLATFORM  android|ios|js|kmp|flutter|hybridCommon
+#   OUTPUTS   newline-delimited `source:destination` pairs (preferred, supports >1 file)
+#   OUTPUT    legacy single destination path (used when OUTPUTS is empty)
 git clone --depth 1 git@github.com:RevenueCat/purchases-error-codes.git ../purchases-error-codes
 
 echo "export ERROR_CODES_SHA=$(git -C ../purchases-error-codes rev-parse HEAD)" >> "${BASH_ENV}"
 
-cp ../purchases-error-codes/generated/"${PLATFORM}".* "${OUTPUT}"
+ssot="../purchases-error-codes"
+platform_dir="${ssot}/generated/${PLATFORM}"
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+copy() {
+  local source="$1" destination="$2"
+  mkdir -p "$(dirname "${destination}")"
+  cp "${source}" "${destination}"
+  echo "Copied ${source} -> ${destination}"
+}
+
+if [[ -n "${OUTPUTS:-}" ]]; then
+  # New layout: one `source:destination` pair per line. `source` names a file under
+  # generated/<platform>/; split on the first colon so destination paths are unaffected.
+  while IFS= read -r line; do
+    line="$(trim "${line}")"
+    [[ -z "${line}" ]] && continue
+    source="$(trim "${line%%:*}")"
+    destination="$(trim "${line#*:}")"
+    copy "${platform_dir}/${source}" "${destination}"
+  done <<< "${OUTPUTS}"
+else
+  # Legacy single-file form. Prefer the per-platform directory (new SSOT layout); fall back
+  # to the old flat generated/<platform>.* while the SSOT migration is in flight.
+  mkdir -p "$(dirname "${OUTPUT}")"
+  if [[ -d "${platform_dir}" ]]; then
+    cp "${platform_dir}"/* "${OUTPUT}"
+  else
+    cp "${ssot}"/generated/"${PLATFORM}".* "${OUTPUT}"
+  fi
+fi

--- a/src/scripts/copy-error-codes.sh
+++ b/src/scripts/copy-error-codes.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-
-# OUTPUT and OUTPUTS are both injected via the job's `environment`; silence the
-# "OUTPUT may not be assigned, did you mean OUTPUTS" heuristic.
-# shellcheck disable=SC2153
 set -euo pipefail
 
 # Clones the error-codes SSOT repo and copies this platform's committed generated files.
@@ -11,50 +7,23 @@ set -euo pipefail
 #
 # Inputs (environment):
 #   PLATFORM  android|ios|js|kmp|flutter|hybridCommon
-#   OUTPUTS   newline-delimited `source:destination` pairs (preferred, supports >1 file)
-#   OUTPUT    legacy single destination path (used when OUTPUTS is empty)
+#   OUTPUTS   newline-delimited `source:destination` pairs, one per generated file
 git clone --depth 1 git@github.com:RevenueCat/purchases-error-codes.git ../purchases-error-codes
 
 echo "export ERROR_CODES_SHA=$(git -C ../purchases-error-codes rev-parse HEAD)" >> "${BASH_ENV}"
 
-ssot="../purchases-error-codes"
-platform_dir="${ssot}/generated/${PLATFORM}"
+platform_dir="../purchases-error-codes/generated/${PLATFORM}"
 
-copy() {
-  local source="$1" destination="$2"
-  mkdir -p "$(dirname "${destination}")"
-  cp "${source}" "${destination}"
-  echo "Copied ${source} -> ${destination}"
-}
-
-if [[ -n "${OUTPUTS:-}" ]]; then
-  # New layout: one `source:destination` pair per line. `source` names a file under
-  # generated/<platform>/; split on the first colon so destination paths are unaffected.
-  while IFS= read -r line; do
-    [[ -z "${line}" ]] && continue
-    if [[ "${line}" != *:* ]]; then
-      echo "Malformed outputs line (expected 'source:destination'): ${line}" >&2
-      exit 1
-    fi
-    copy "${platform_dir}/${line%%:*}" "${line#*:}"
-  done <<< "${OUTPUTS}"
-elif [[ -n "${OUTPUT:-}" ]]; then
-  # Legacy single-file form. Prefer the per-platform directory (new SSOT layout); fall back
-  # to the old flat generated/<platform>.* while the SSOT migration is in flight.
-  mkdir -p "$(dirname "${OUTPUT}")"
-  if [[ -d "${platform_dir}" ]]; then
-    shopt -s nullglob
-    platform_files=("${platform_dir}"/*)
-    shopt -u nullglob
-    if [[ ${#platform_files[@]} -ne 1 ]]; then
-      echo "Platform ${PLATFORM} produces ${#platform_files[@]} files; use the 'outputs' parameter instead of 'output'." >&2
-      exit 1
-    fi
-    cp "${platform_files[0]}" "${OUTPUT}"
-  else
-    cp "${ssot}"/generated/"${PLATFORM}".* "${OUTPUT}"
+# One `source:destination` pair per line. `source` names a file under generated/<platform>/;
+# split on the first colon so destination paths are unaffected.
+while IFS= read -r line; do
+  [[ -z "${line}" ]] && continue
+  if [[ "${line}" != *:* ]]; then
+    echo "Malformed outputs line (expected 'source:destination'): ${line}" >&2
+    exit 1
   fi
-else
-  echo "Neither 'outputs' nor 'output' is set; nothing to copy." >&2
-  exit 1
-fi
+  destination="${line#*:}"
+  mkdir -p "$(dirname "${destination}")"
+  cp "${platform_dir}/${line%%:*}" "${destination}"
+  echo "Copied ${line%%:*} -> ${destination}"
+done <<< "${OUTPUTS}"

--- a/src/scripts/copy-error-codes.sh
+++ b/src/scripts/copy-error-codes.sh
@@ -53,7 +53,9 @@ elif [[ -n "${OUTPUT:-}" ]]; then
   # to the old flat generated/<platform>.* while the SSOT migration is in flight.
   mkdir -p "$(dirname "${OUTPUT}")"
   if [[ -d "${platform_dir}" ]]; then
+    shopt -s nullglob
     platform_files=("${platform_dir}"/*)
+    shopt -u nullglob
     if [[ ${#platform_files[@]} -ne 1 ]]; then
       echo "Platform ${PLATFORM} produces ${#platform_files[@]} files; use the 'outputs' parameter instead of 'output'." >&2
       exit 1

--- a/src/scripts/copy-error-codes.sh
+++ b/src/scripts/copy-error-codes.sh
@@ -40,17 +40,29 @@ if [[ -n "${OUTPUTS:-}" ]]; then
   while IFS= read -r line; do
     line="$(trim "${line}")"
     [[ -z "${line}" ]] && continue
+    if [[ "${line}" != *:* ]]; then
+      echo "Malformed outputs line (expected 'source:destination'): ${line}" >&2
+      exit 1
+    fi
     source="$(trim "${line%%:*}")"
     destination="$(trim "${line#*:}")"
     copy "${platform_dir}/${source}" "${destination}"
   done <<< "${OUTPUTS}"
-else
+elif [[ -n "${OUTPUT:-}" ]]; then
   # Legacy single-file form. Prefer the per-platform directory (new SSOT layout); fall back
   # to the old flat generated/<platform>.* while the SSOT migration is in flight.
   mkdir -p "$(dirname "${OUTPUT}")"
   if [[ -d "${platform_dir}" ]]; then
-    cp "${platform_dir}"/* "${OUTPUT}"
+    platform_files=("${platform_dir}"/*)
+    if [[ ${#platform_files[@]} -ne 1 ]]; then
+      echo "Platform ${PLATFORM} produces ${#platform_files[@]} files; use the 'outputs' parameter instead of 'output'." >&2
+      exit 1
+    fi
+    cp "${platform_files[0]}" "${OUTPUT}"
   else
     cp "${ssot}"/generated/"${PLATFORM}".* "${OUTPUT}"
   fi
+else
+  echo "Neither 'outputs' nor 'output' is set; nothing to copy." >&2
+  exit 1
 fi

--- a/src/scripts/copy-error-codes.sh
+++ b/src/scripts/copy-error-codes.sh
@@ -20,13 +20,6 @@ echo "export ERROR_CODES_SHA=$(git -C ../purchases-error-codes rev-parse HEAD)" 
 ssot="../purchases-error-codes"
 platform_dir="${ssot}/generated/${PLATFORM}"
 
-trim() {
-  local value="$1"
-  value="${value#"${value%%[![:space:]]*}"}"
-  value="${value%"${value##*[![:space:]]}"}"
-  printf '%s' "${value}"
-}
-
 copy() {
   local source="$1" destination="$2"
   mkdir -p "$(dirname "${destination}")"
@@ -38,15 +31,12 @@ if [[ -n "${OUTPUTS:-}" ]]; then
   # New layout: one `source:destination` pair per line. `source` names a file under
   # generated/<platform>/; split on the first colon so destination paths are unaffected.
   while IFS= read -r line; do
-    line="$(trim "${line}")"
     [[ -z "${line}" ]] && continue
     if [[ "${line}" != *:* ]]; then
       echo "Malformed outputs line (expected 'source:destination'): ${line}" >&2
       exit 1
     fi
-    source="$(trim "${line%%:*}")"
-    destination="$(trim "${line#*:}")"
-    copy "${platform_dir}/${source}" "${destination}"
+    copy "${platform_dir}/${line%%:*}" "${line#*:}"
   done <<< "${OUTPUTS}"
 elif [[ -n "${OUTPUT:-}" ]]; then
   # Legacy single-file form. Prefer the per-platform directory (new SSOT layout); fall back

--- a/src/scripts/stop-if-error-codes-unchanged.sh
+++ b/src/scripts/stop-if-error-codes-unchanged.sh
@@ -1,12 +1,37 @@
 #!/usr/bin/env bash
+
+# OUTPUT and OUTPUTS are both injected via the job's `environment`; silence the
+# "OUTPUT may not be assigned, did you mean OUTPUTS" heuristic.
+# shellcheck disable=SC2153
 set -euo pipefail
 
-# Halts the job (success) when the generated file is unchanged, skipping the API dump and PR.
+# Halts the job (success) when every generated file is unchanged, skipping the API dump and PR.
 # Uses `git status --porcelain` (not `git diff`) so a brand-new untracked file or a
 # staged change still counts as "changed" — `git diff --quiet` reports untracked files
 # as no-change and would wrongly halt on first adoption of a new platform.
-# Inputs (environment): OUTPUT (repo-root-relative path of the generated file).
-if [ -z "$(git status --porcelain -- "${OUTPUT}")" ]; then
+#
+# Inputs (environment):
+#   OUTPUTS  newline-delimited `source:destination` pairs (preferred)
+#   OUTPUT   legacy single destination path (used when OUTPUTS is empty)
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+destinations=()
+if [[ -n "${OUTPUTS:-}" ]]; then
+  while IFS= read -r line; do
+    line="$(trim "${line}")"
+    [[ -z "${line}" ]] && continue
+    destinations+=("$(trim "${line#*:}")")
+  done <<< "${OUTPUTS}"
+else
+  destinations+=("${OUTPUT}")
+fi
+
+if [ -z "$(git status --porcelain -- "${destinations[@]}")" ]; then
   echo "Generated error codes are up to date. Nothing to do."
   circleci-agent step halt
 fi

--- a/src/scripts/stop-if-error-codes-unchanged.sh
+++ b/src/scripts/stop-if-error-codes-unchanged.sh
@@ -27,8 +27,13 @@ if [[ -n "${OUTPUTS:-}" ]]; then
     [[ -z "${line}" ]] && continue
     destinations+=("$(trim "${line#*:}")")
   done <<< "${OUTPUTS}"
-else
+elif [[ -n "${OUTPUT:-}" ]]; then
   destinations+=("${OUTPUT}")
+fi
+
+if [[ ${#destinations[@]} -eq 0 ]]; then
+  echo "Neither 'outputs' nor 'output' resolved to a destination path." >&2
+  exit 1
 fi
 
 if [ -z "$(git status --porcelain -- "${destinations[@]}")" ]; then

--- a/src/scripts/stop-if-error-codes-unchanged.sh
+++ b/src/scripts/stop-if-error-codes-unchanged.sh
@@ -25,6 +25,10 @@ if [[ -n "${OUTPUTS:-}" ]]; then
   while IFS= read -r line; do
     line="$(trim "${line}")"
     [[ -z "${line}" ]] && continue
+    if [[ "${line}" != *:* ]]; then
+      echo "Malformed outputs line (expected 'source:destination'): ${line}" >&2
+      exit 1
+    fi
     destinations+=("$(trim "${line#*:}")")
   done <<< "${OUTPUTS}"
 elif [[ -n "${OUTPUT:-}" ]]; then

--- a/src/scripts/stop-if-error-codes-unchanged.sh
+++ b/src/scripts/stop-if-error-codes-unchanged.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-
-# OUTPUT and OUTPUTS are both injected via the job's `environment`; silence the
-# "OUTPUT may not be assigned, did you mean OUTPUTS" heuristic.
-# shellcheck disable=SC2153
 set -euo pipefail
 
 # Halts the job (success) when every generated file is unchanged, skipping the API dump and PR.
@@ -11,24 +7,15 @@ set -euo pipefail
 # as no-change and would wrongly halt on first adoption of a new platform.
 #
 # Inputs (environment):
-#   OUTPUTS  newline-delimited `source:destination` pairs (preferred)
-#   OUTPUT   legacy single destination path (used when OUTPUTS is empty)
+#   OUTPUTS  newline-delimited `source:destination` pairs
 destinations=()
-if [[ -n "${OUTPUTS:-}" ]]; then
-  while IFS= read -r line; do
-    [[ -z "${line}" ]] && continue
-    if [[ "${line}" != *:* ]]; then
-      echo "Malformed outputs line (expected 'source:destination'): ${line}" >&2
-      exit 1
-    fi
-    destinations+=("${line#*:}")
-  done <<< "${OUTPUTS}"
-elif [[ -n "${OUTPUT:-}" ]]; then
-  destinations+=("${OUTPUT}")
-fi
+while IFS= read -r line; do
+  [[ -z "${line}" ]] && continue
+  destinations+=("${line#*:}")
+done <<< "${OUTPUTS}"
 
 if [[ ${#destinations[@]} -eq 0 ]]; then
-  echo "Neither 'outputs' nor 'output' resolved to a destination path." >&2
+  echo "No destination paths resolved from 'outputs'." >&2
   exit 1
 fi
 

--- a/src/scripts/stop-if-error-codes-unchanged.sh
+++ b/src/scripts/stop-if-error-codes-unchanged.sh
@@ -13,23 +13,15 @@ set -euo pipefail
 # Inputs (environment):
 #   OUTPUTS  newline-delimited `source:destination` pairs (preferred)
 #   OUTPUT   legacy single destination path (used when OUTPUTS is empty)
-trim() {
-  local value="$1"
-  value="${value#"${value%%[![:space:]]*}"}"
-  value="${value%"${value##*[![:space:]]}"}"
-  printf '%s' "${value}"
-}
-
 destinations=()
 if [[ -n "${OUTPUTS:-}" ]]; then
   while IFS= read -r line; do
-    line="$(trim "${line}")"
     [[ -z "${line}" ]] && continue
     if [[ "${line}" != *:* ]]; then
       echo "Malformed outputs line (expected 'source:destination'): ${line}" >&2
       exit 1
     fi
-    destinations+=("$(trim "${line#*:}")")
+    destinations+=("${line#*:}")
   done <<< "${OUTPUTS}"
 elif [[ -n "${OUTPUT:-}" ]]; then
   destinations+=("${OUTPUT}")


### PR DESCRIPTION
For KMP (mapping files per native sourceset) and Flutter (which has a  test with an exhaustive check over the enum)

```yaml
          platform: kmp
          outputs: |
            PurchasesErrorCode.kt:models/src/commonMain/kotlin/generated/com/revenuecat/purchases/kmp/models/PurchasesErrorCode.kt
            errors.android.kt:mappings/src/androidMain/kotlin/com/revenuecat/purchases/kmp/mappings/errors.android.kt
            errors.ios.kt:mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/errors.ios.kt
```

```yaml
          platform: flutter
          outputs: |
            errors.dart:lib/src/generated/error_codes.dart
            errors_api_test.dart:api_tester/lib/api_tests/errors_api_test.dart
```