### PR TITLE
update-error-codes: nudge stale update PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Current development changes [ to be moved to release ]
+- `update-error-codes`: nudge an `update-error-codes` PR that has stayed open for over a day with a comment mentioning `@RevenueCat/coresdk`.
 
 ## [1.0.0] - 2021-03-11
 

--- a/src/jobs/update-error-codes.yml
+++ b/src/jobs/update-error-codes.yml
@@ -51,3 +51,6 @@ steps:
       environment:
         COMMIT_PATHS: << parameters.commit_paths >>
       command: <<include(scripts/open-error-codes-pr.sh)>>
+  - run:
+      name: Nudge stale error-codes PR
+      command: <<include(scripts/nudge-stale-error-codes-pr.sh)>>

--- a/src/scripts/nudge-stale-error-codes-pr.sh
+++ b/src/scripts/nudge-stale-error-codes-pr.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Nudges the open update-error-codes PR when it has been ignored for over a day. Runs after the PR
+# was opened/updated, so reaching here means the codes drifted from the SSOT; a PR just opened by
+# this run is younger than the threshold and is left alone. Daily scheduling keeps this to one ping
+# per day. Uses the GITHUB_TOKEN the PR step already requires.
+
+repo="RevenueCat/$(basename -s .git "$(git config --get remote.origin.url)")"
+
+gh_api() {
+  curl --silent --show-error --fail --location \
+    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "Accept: application/vnd.github+json" \
+    "$@"
+}
+
+pr="$(gh_api "https://api.github.com/repos/${repo}/pulls?head=RevenueCat:update-error-codes&state=open")" || {
+  echo "Could not query open PRs; skipping nudge." >&2
+  exit 0
+}
+
+number="$(jq -r '.[0].number // empty' <<<"$pr")"
+if [[ -z "$number" ]]; then
+  echo "No open update-error-codes PR; nothing to nudge."
+  exit 0
+fi
+
+created_at="$(jq -r '.[0].created_at' <<<"$pr")"
+created_epoch="$(date -u -d "$created_at" +%s)"
+age_hours=$(( ($(date -u +%s) - created_epoch) / 3600 ))
+if (( age_hours < 24 )); then
+  echo "PR #${number} is ${age_hours}h old (< 24h); not nudging yet."
+  exit 0
+fi
+
+# shellcheck disable=SC2016  # backticks are literal markdown; no shell expansion intended
+body='@RevenueCat/coresdk this `update-error-codes` PR has been open for over a day. The generated error codes have drifted from the [SSOT](https://github.com/RevenueCat/purchases-error-codes); please review and merge.'
+if gh_api --data "$(jq -n --arg body "$body" '{body: $body}')" \
+    "https://api.github.com/repos/${repo}/issues/${number}/comments" > /dev/null; then
+  echo "Nudged PR #${number}."
+else
+  echo "Failed to comment on PR #${number}; continuing." >&2
+fi


### PR DESCRIPTION
Adds a step to the `update-error-codes` job that nudges a stale update PR.

When the job opens/refreshes the `update-error-codes` PR, the new `nudge-stale-error-codes-pr.sh` checks the open PR's age: if it has been open over a day, it posts a comment mentioning `@RevenueCat/coresdk`. Fresh PRs (<24h, including one just opened in the same run) are left alone, so a daily run nudges at most once per day.

Driven by the SSOT's daily freshness trigger: https://github.com/RevenueCat/purchases-error-codes/pull/23

Closes SDK-4378
