### PR TITLE
Add install-mise-tools command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   <orb-name>: revenuecat/sdks-common-config@dev:<<pipeline.git.revision>>
   orb-tools: circleci/orb-tools@11.1
+  android: circleci/android@3.1.0
 
 filters: &filters
   tags:
@@ -140,6 +141,27 @@ jobs:
             export PATH="$HOME/.local/share/mise/shims:$PATH"
             swiftlint version
 
+  test-install-mise-tools:
+    executor:
+      name: android/android_machine
+      resource_class: large
+      tag: default
+    shell: /bin/bash --login -o pipefail
+    steps:
+      - checkout
+      - run:
+          name: Copy Java test fixture
+          command: cp test-fixtures/mise-java.toml mise.toml
+      - <orb-name>/install-mise-tools
+      - run:
+          name: Verify Java from mise.toml
+          # Intentionally does not re-export PATH or JAVA_HOME: this job verifies
+          # that install-mise-tools persists them to BASH_ENV for subsequent steps.
+          command: |
+            java -version
+            test -n "$JAVA_HOME"
+            "$JAVA_HOME/bin/java" -version
+
   test-install-xcodes:
     macos:
       xcode: 26.3.0
@@ -209,6 +231,10 @@ workflows:
           requires:
             - orb-tools/pack
           filters: *filters
+      - test-install-mise-tools:
+          requires:
+            - orb-tools/pack
+          filters: *filters
       - test-install-xcodes:
           requires:
             - orb-tools/pack
@@ -242,6 +268,7 @@ workflows:
             - test-install-public-api-diff
             - test-install-maestro
             - test-install-swiftlint
+            - test-install-mise-tools
             - test-install-xcodes
             - test-install-xcbeautify
             - test-install-xcbeautify-from-mise-toml

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -155,12 +155,13 @@ jobs:
       - <orb-name>/install-mise-tools
       - run:
           name: Verify Java from mise.toml
-          # Intentionally does not re-export PATH or JAVA_HOME: this job verifies
-          # that install-mise-tools persists them to BASH_ENV for subsequent steps.
+          # Intentionally does not re-export PATH or JAVA_HOME: verifies install-mise-tools
+          # persisted them to BASH_ENV (install-mise persists shims; this step sets JAVA_HOME).
           command: |
+            test -f /tmp/mise-tools-postinstall-test
             java -version
             test -n "$JAVA_HOME"
-            "$JAVA_HOME/bin/java" -version
+            test "$JAVA_HOME" = "$(mise where java)"
 
   test-install-xcodes:
     macos:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `install-mise-tools`: installs mise and all tools from the repository's `mise.toml`, including postinstall hooks; sets `JAVA_HOME` when java is configured.
 - Current development changes [ to be moved to release ]
 - `update-error-codes`: nudge an `update-error-codes` PR that has stayed open for over a day with a comment mentioning `@RevenueCat/coresdk`.
 

--- a/src/commands/install-mise-tools.yml
+++ b/src/commands/install-mise-tools.yml
@@ -1,0 +1,8 @@
+description: >
+  Installs mise and all tools declared in the repository's mise.toml (including
+  postinstall hooks). Sets JAVA_HOME when java is configured.
+steps:
+  - install-mise
+  - run:
+      name: Install mise tools
+      command: <<include(scripts/install-mise-tools.sh)>>

--- a/src/commands/install-mise.yml
+++ b/src/commands/install-mise.yml
@@ -1,7 +1,7 @@
 description: >
   Installs a pinned version of the mise tool version manager, verifying the
   downloaded archive against a known SHA256. Used as a prerequisite step by
-  install-tuist and install-swiftlint.
+  install-mise-tools, install-tuist, and install-swiftlint.
 steps:
   - run:
       name: Install mise

--- a/src/scripts/install-mise-tools.sh
+++ b/src/scripts/install-mise-tools.sh
@@ -8,6 +8,9 @@ if [ ! -f "mise.toml" ]; then
     exit 1
 fi
 
+# Required for [hooks] postinstall tasks (e.g. link-jdks) in consumer mise.toml files.
+mise settings set experimental true
+
 mise install
 
 export PATH="$HOME/.local/share/mise/shims:$PATH"

--- a/src/scripts/install-mise-tools.sh
+++ b/src/scripts/install-mise-tools.sh
@@ -1,25 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# mise is installed by the install-mise command in this orb; assume it is on PATH.
-
 if [ ! -f "mise.toml" ]; then
     echo "❌ mise.toml not found. Please create a mise.toml file with tool versions."
     exit 1
 fi
 
-# Required for [hooks] postinstall tasks (e.g. link-jdks) in consumer mise.toml files.
+# Consumer postinstall hooks (e.g. link-jdks) require experimental mode.
 mise settings set experimental true
 
 mise install
 
-export PATH="$HOME/.local/share/mise/shims:$PATH"
-
-if mise which java >/dev/null 2>&1; then
-    java_home="$(mise where java)"
+if java_home="$(mise where java 2>/dev/null)"; then
     echo "export JAVA_HOME=\"$java_home\"" >> "$BASH_ENV"
-    echo "Set JAVA_HOME to $java_home"
-    java -version
+    java -version || { echo "❌ Java did not install properly."; exit 1; }
 fi
 
 echo "✅ mise tools installation completed"

--- a/src/scripts/install-mise-tools.sh
+++ b/src/scripts/install-mise-tools.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mise is installed by the install-mise command in this orb; assume it is on PATH.
+
+if [ ! -f "mise.toml" ]; then
+    echo "❌ mise.toml not found. Please create a mise.toml file with tool versions."
+    exit 1
+fi
+
+mise install
+
+export PATH="$HOME/.local/share/mise/shims:$PATH"
+
+if mise which java >/dev/null 2>&1; then
+    java_home="$(mise where java)"
+    echo "export JAVA_HOME=\"$java_home\"" >> "$BASH_ENV"
+    echo "Set JAVA_HOME to $java_home"
+    java -version
+fi
+
+echo "✅ mise tools installation completed"

--- a/test-fixtures/mise-java.toml
+++ b/test-fixtures/mise-java.toml
@@ -1,0 +1,5 @@
+[settings]
+lockfile = true
+
+[tools]
+java = "liberica-17.0.6"

--- a/test-fixtures/mise-java.toml
+++ b/test-fixtures/mise-java.toml
@@ -1,5 +1,5 @@
-[settings]
-lockfile = true
-
 [tools]
 java = "liberica-17.0.6"
+
+[hooks]
+postinstall = "touch /tmp/mise-tools-postinstall-test"


### PR DESCRIPTION
## Motivation

SDK repos are moving from SDKMAN (`.sdkmanrc`) to repo-root `mise.toml` for local/CI tool parity. CI needs a single orb command that installs mise, runs `mise install` from the consumer repo, and wires `JAVA_HOME` (if java is present) so Gradle uses the pinned JDK instead of the image default.

The idea long-term is that every SDK repo (java or not) will define its deps/postinstall in `mise.toml` and a single call to this job (or `mise install` locally) would set everything up.

## Description

Adds `install-mise-tools`:

- Depends on existing `install-mise`
- Enables mise experimental hooks (needed for consumer postinstall tasks like `link-jdks`)
- Runs `mise install` from the repo `mise.toml`
- Prepends mise shims to `PATH` and writes `JAVA_HOME` to `$BASH_ENV` when `java` is configured

Also adds `test-install-mise-tools` on `android/android_machine` (fixture: `test-fixtures/mise-java.toml`) and a CHANGELOG entry.

## Consumer

Draft verification in RevenueCat/purchases-android#3727 (`@dev:4d6f65b938032a715bc4e60d0dfbff793eec3f89`).

## Checklist

- [x] test-deploy job for Linux Android executor
- [ ] Merge and tag orb release
- [ ] Bump consumer repos off `@dev:...`