### PR TITLE
fix: Separate gem cache by Ruby version and architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `install-gem-dependencies`: include the architecture and Ruby version in the gem cache key so jobs running on different Rubies no longer collide on a single immutable key (which previously forced repeated `bundle install` reinstalls). Also add a partial-restore fallback key so a `Gemfile.lock` change reuses the previous bundle and installs only the delta.
 - `install-mise-tools`: installs mise and all tools from the repository's `mise.toml`, including postinstall hooks; sets `JAVA_HOME` when java is configured.
 - `install-mise-tools`: `locked` parameter (default `true`) runs `mise install --locked` so CI does not rewrite `mise.lock`.
 - `install-mise`: bump pinned mise to v2026.7.0 (lockfile write fixes with `--locked`).

--- a/src/commands/install-gem-dependencies.yml
+++ b/src/commands/install-gem-dependencies.yml
@@ -10,14 +10,25 @@ parameters:
     type: string
     default: .
 steps:
+  - run:
+      name: Capture Ruby version for the gem cache key
+      # Cache keys can't reference the Ruby version directly, so we checksum a file
+      # containing it (same approach as the Kotlin/Native cache). This keeps gem caches
+      # separated per Ruby version and architecture, so jobs running on different Rubies
+      # don't collide on a single key (a cache key is immutable, so the first Ruby to
+      # populate it would otherwise force every other Ruby to reinstall on every run).
+      command: ruby --version > ~/.ruby_version
   - restore_cache:
       keys:
-        - <<parameters.cache-version>>-<<parameters.cache-prefix>>-gem-cache-{{ checksum "<< parameters.working_directory >>/Gemfile.lock" }}
+        - <<parameters.cache-version>>-<<parameters.cache-prefix>>-gem-cache-{{ arch }}-{{ checksum "~/.ruby_version" }}-{{ checksum "<< parameters.working_directory >>/Gemfile.lock" }}
+        # Fallback: reuse the most recent bundle for this Ruby/arch and install only the
+        # delta when Gemfile.lock changed (bundle config clean=true prunes stale gems).
+        - <<parameters.cache-version>>-<<parameters.cache-prefix>>-gem-cache-{{ arch }}-{{ checksum "~/.ruby_version" }}-
   - run:
       name: Bundle install
       working_directory: << parameters.working_directory >>
       command: <<include(scripts/bundle-install.sh)>>
   - save_cache:
-      key: <<parameters.cache-version>>-<<parameters.cache-prefix>>-gem-cache-{{ checksum "<< parameters.working_directory >>/Gemfile.lock" }}
+      key: <<parameters.cache-version>>-<<parameters.cache-prefix>>-gem-cache-{{ arch }}-{{ checksum "~/.ruby_version" }}-{{ checksum "<< parameters.working_directory >>/Gemfile.lock" }}
       paths:
         - vendor/bundle


### PR DESCRIPTION
## Motivation

Consuming SDK repos see the CI `bundle install` step run slowly and repeatedly, despite gem caching being configured through this orb.

From what I understand, it might be due to cache collisions with different architectures and/or ruby versions. So this PR adds those to the cache key so they can be properly split 