### PR TITLE
Fix install-mise-tools hooks:false not actually suppressing mise hooks

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -160,7 +160,7 @@ jobs:
           # Intentionally does not re-export PATH or JAVA_HOME: verifies install-mise-tools
           # persisted them to BASH_ENV (install-mise persists shims; this step sets JAVA_HOME).
           command: |
-            test -f /tmp/mise-tools-postinstall-test
+            test ! -f /tmp/mise-tools-postinstall-test
             java -version
             test -n "$JAVA_HOME"
             test "$JAVA_HOME" = "$(mise where java)"

--- a/src/commands/install-mise-tools.yml
+++ b/src/commands/install-mise-tools.yml
@@ -22,8 +22,10 @@ parameters:
     type: boolean
     default: false
     description: >
-      When true, enables mise experimental mode so project-level [hooks]
-      postinstall in mise.toml runs during install.
+      When false (default), suppresses mise project-level [hooks] (e.g. postinstall)
+      via MISE_NO_HOOKS: mise runs hooks on every `mise install` regardless of which
+      tools were requested, so most callers don't want them firing on every call.
+      Set to true to allow hooks to run.
   project_root:
     type: string
     default: ""
@@ -32,12 +34,6 @@ parameters:
       Use when the job working_directory is a subdirectory of the repo.
 steps:
   - install-mise
-  - when:
-      condition: << parameters.hooks >>
-      steps:
-        - run:
-            name: Enable mise experimental for hooks
-            command: mise settings set experimental true
   - run:
       name: Install mise tools
       command: <<include(scripts/install-mise-tools.sh)>>
@@ -45,3 +41,4 @@ steps:
         MISE_INSTALL_LOCKED: << parameters.locked >>
         MISE_PROJECT_ROOT: << parameters.project_root >>
         MISE_TOOLS: << parameters.tools >>
+        MISE_HOOKS: << parameters.hooks >>

--- a/src/scripts/install-mise-tools.sh
+++ b/src/scripts/install-mise-tools.sh
@@ -10,6 +10,14 @@ if [ ! -f "mise.toml" ]; then
     exit 1
 fi
 
+# mise runs project [hooks] (e.g. postinstall) on every `mise install`, regardless of
+# which tools were requested. Suppress them unless explicitly opted in: most callers
+# don't need them, and paying for e.g. a postinstall task meant for one tool on every
+# call (including single-tool calls via MISE_TOOLS) is wasteful and can hang CI.
+if [ "${MISE_HOOKS:-false}" != "true" ]; then
+    export MISE_NO_HOOKS=1
+fi
+
 install_args=()
 if [ "${MISE_INSTALL_LOCKED:-true}" != "false" ]; then
     install_args+=(--locked)


### PR DESCRIPTION
The parameter was not actually wired to the env variable