### PR TITLE
Cache mise data directory in install-mise-tools

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -164,6 +164,18 @@ jobs:
             java -version
             test -n "$JAVA_HOME"
             test "$JAVA_HOME" = "$(mise where java)"
+      - run:
+          name: Verify cache key inputs and pruned downloads
+          command: |
+            test -f ~/.mise_version
+            test "$(cat ~/.mise_version)" = "$(mise --version)"
+            leftover="$(find "$HOME/.local/share/mise/downloads" -type f 2>/dev/null)"
+            if [ -n "$leftover" ]; then
+                echo "ERROR: downloads/ still holds files; they would be cached" >&2
+                echo "$leftover" >&2
+                exit 1
+            fi
+            echo "OK: cache key inputs present, downloads pruned"
 
   test-install-mise-tools-selective:
     executor:
@@ -178,6 +190,8 @@ jobs:
           command: |
             cp test-fixtures/mise-java.toml mise.toml
             cp test-fixtures/mise-java.lock mise.lock
+      # Same fixture as test-install-mise-tools, different tools: the two must
+      # not collide on one immutable cache key.
       - <orb-name>/install-mise-tools:
           hooks: true
           tools: java

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `install-mise-tools`: `locked` parameter (default `true`) runs `mise install --locked` so CI does not rewrite `mise.lock`.
 - `install-mise-tools`: `tools` parameter (comma-separated string, default `""`) installs a subset by name from the consumer's `mise.toml` (e.g. `tools: node,yarn`); empty installs all tools.
 - `install-mise-tools`: `hooks` parameter (default `false`) enables mise experimental mode when project-level `[hooks]` postinstall must run.
-- `install-mise-tools`: `project_root` parameter cd's to the directory containing `mise.toml` before installing.
+- `install-mise-tools`: `project_root` parameter cd's to the directory containing `mise.toml` before installing. Its default changed from `""` to `"."` so the mise config files can be checksummed into the cache key; behavior is unchanged.
+- `install-mise-tools`: `cache` parameter (default `true`) caches `~/.local/share/mise` between runs, so warm jobs no longer download toolchains from their upstream suppliers. Keyed on architecture, mise version, tool selection and both mise config files; a change to any of them misses and the job downloads as it does today. Ignored when `locked` is false. Set to `false` where restoring the toolset costs more than downloading it.
+- `install-mise-tools`: `cache_prefix` parameter (default `v1`) to invalidate every mise cache.
+- `install-mise`: write `~/.mise_version` so callers can key caches on the mise version.
 - `install-mise`: bump pinned mise to v2026.7.0 (lockfile write fixes with `--locked`).
 - Current development changes [ to be moved to release ]
 - `update-error-codes`: nudge an `update-error-codes` PR that has stayed open for over a day with a comment mentioning `@RevenueCat/coresdk`.

--- a/src/commands/install-mise-tools.yml
+++ b/src/commands/install-mise-tools.yml
@@ -2,7 +2,8 @@ description: >
   Installs mise and tools declared in the repository's mise.toml. Sets JAVA_HOME
   when java is configured. Pass tools as comma-separated mise tool IDs from the
   consumer's mise.toml (e.g. "node,yarn"). When tools is empty, installs all
-  tools from mise.toml.
+  tools from mise.toml. Caches the mise data directory between runs so warm jobs
+  do not download toolchains from their upstream suppliers.
 parameters:
   locked:
     type: boolean
@@ -17,7 +18,8 @@ parameters:
     description: >
       Comma-separated mise tool IDs to install (e.g. "java" or "node,yarn").
       Names must match entries in the consumer's mise.toml. Omit or leave empty
-      to install all tools declared in mise.toml.
+      to install all tools declared in mise.toml. Must not contain spaces: the
+      install script tolerates them but the cache key is used verbatim.
   hooks:
     type: boolean
     default: false
@@ -28,12 +30,35 @@ parameters:
       Set to true to allow hooks to run.
   project_root:
     type: string
-    default: ""
+    default: "."
     description: >
-      Directory containing mise.toml. When set, cd there before installing.
-      Use when the job working_directory is a subdirectory of the repo.
+      Directory containing mise.toml. cd there before installing. Use when the
+      job working_directory is a subdirectory of the repo.
+  cache:
+    type: boolean
+    default: true
+    description: >
+      Cache ~/.local/share/mise keyed on the platform, mise version, tool
+      selection and both mise config files. Ignored when locked is false, since
+      without a lockfile the declared versions may float and the key would pin a
+      stale resolution. Set to false for toolsets large enough that restoring
+      them costs more than downloading them.
+  cache_prefix:
+    type: string
+    default: v1
+    description: >
+      Used to form part of the cache key. Bump to invalidate every mise cache.
 steps:
   - install-mise
+  - when:
+      condition:
+        and:
+          - << parameters.cache >>
+          - << parameters.locked >>
+      steps:
+        - restore_cache:
+            keys:
+              - &cache_key <<parameters.cache_prefix>>-mise-{{ arch }}-{{ checksum "~/.mise_version" }}-<<parameters.tools>>-{{ checksum "<< parameters.project_root >>/mise.toml" }}-{{ checksum "<< parameters.project_root >>/mise.lock" }}
   - run:
       name: Install mise tools
       command: <<include(scripts/install-mise-tools.sh)>>
@@ -42,3 +67,20 @@ steps:
         MISE_PROJECT_ROOT: << parameters.project_root >>
         MISE_TOOLS: << parameters.tools >>
         MISE_HOOKS: << parameters.hooks >>
+  - when:
+      condition:
+        and:
+          - << parameters.cache >>
+          - << parameters.locked >>
+      steps:
+        # mise documents downloads/ as a debugging aid, not a download cache, so
+        # nothing reads these back: https://mise.jdx.dev/configuration/settings.html
+        - run:
+            name: Prune mise downloads before caching
+            command: rm -rf "$HOME/.local/share/mise/downloads"/*
+        - save_cache:
+            key: *cache_key
+            paths:
+              # save_cache does not expand environment variables, so a consumer
+              # overriding MISE_DATA_DIR or XDG_DATA_HOME is not supported here.
+              - ~/.local/share/mise

--- a/src/scripts/install-mise.sh
+++ b/src/scripts/install-mise.sh
@@ -72,3 +72,6 @@ export PATH="$HOME/.local/share/mise/shims:$PATH"
 # Persist PATH changes to BASH_ENV so mise and its shims are available in
 # subsequent CircleCI run steps (each step starts a fresh shell).
 echo "export PATH=\"\$HOME/.local/bin:\$HOME/.local/share/mise/shims:\$PATH\"" >> "$BASH_ENV"
+
+# CircleCI cache keys can checksum a file but not a command's output.
+mise --version > "$HOME/.mise_version"


### PR DESCRIPTION
- Caches `~/.local/share/mise` in `install-mise-tools`, so warm jobs stop downloading toolchains from their upstream suppliers. Defaults on, and orb versions are pinned per repo, so consumers pick it up when they bump.
- Why? Faster (in most cases) and reduces reliance on suppliers (e.g. if github downloads fail)
- Keyed on architecture, mise version, tool selection and both mise config files. Exact match only, no fallback: a miss just downloads, as today.
- The tool selection must be in the key. Keys are immutable, so without it the first selection to run would define the cache for every other one.
- `install-mise` now writes `~/.mise_version`. `project_root` defaults to `"."` instead of `""` so the config files are checksummable inline; `cd "."` is a no-op, so behavior is unchanged.


<details><summary>Agent description</summary>

Cold vs warm on the `mise-java.toml` fixture (Linux, single JDK):

| step | cold | warm |
|---|---|---|
| Restoring cache | 0s | 3s |
| Install mise tools | 5s | 0s |
| Saving cache | 3s | 0s |

Break-even for one JDK; savings scale with toolset size. Measured per-tool on macOS arm64: java 319M/version, ruby 147M, node 195M, tuist 600M, flutter ~3.9G. `save_cache` costs 0s on a hit, which is why it is not conditionally skipped.

**Regression gate:** `test-install-mise-tools` and `-selective` share a fixture and differ only in `tools`, so they must resolve to distinct keys. The new assertion step also checks `~/.mise_version` matches `mise --version` and that `downloads/` is empty at save time.

**Limitations:**
- `MISE_DATA_DIR` / `XDG_DATA_HOME` overrides unsupported: `save_cache` paths do not expand env vars, so honoring an override only in the prune step would silently archive the wrong directory.
- Caches are per project, so nothing is shared across repos.
- Calling the command twice in one job with different `tools` stores both tool sets in the second cache.

**Rejected:**
- Downloads-only cache, which would keep checksum verification. mise documents `always_keep_download` as "not a supported download cache", and `core:ruby` with `compile = false` re-downloads unconditionally.
- One shared key per repo. A bare `mise install --locked` cannot work on mixed-executor repos: tuist ships no Linux binary, so purchases-ios's Linux jobs abort with `not in the lockfile`. Not fixable by re-locking. A warmer job would work but needs per-repo workflow edits and a hand-maintained per-arch tool list.
- Per-tool caches. Caches are per project, so this only dedupes within a repo, where the tool union is nearly the whole `mise.toml`.

`http-tarballs/` and `plugins/` are why the whole data directory is cached: `installs/flutter` is absolute symlinks into the former, and `install-xcodes.sh` populates the latter. Those absolute symlinks are also why `{{ arch }}` is load-bearing.

</details>
